### PR TITLE
Confirmation handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+
+# IntelliJ IDEA specific
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -23,3 +23,10 @@ publishTo <<= (version)(version =>
     if (version endsWith "SNAPSHOT") Some("Gawker Snapshots" at "https://nexus.kinja-ops.com/nexus/content/repositories/snapshots/")
     else                             Some("Gawker Releases" at "https://nexus.kinja-ops.com/nexus/content/repositories/releases/")
 )
+
+// External plugins
+scalariformSettings
+
+// code formatting
+ScalariformKeys.preferences := scalariform.formatter.preferences.FormattingPreferences().
+    setPreference(scalariform.formatter.preferences.IndentWithTabs, true)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += "Gawker Public Group" at "https://nexus.kinja-ops.com/nexus/content/groups/public"
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")

--- a/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
@@ -15,10 +15,12 @@ trait AmqpClientProvider {
 
 	protected val logger: Slf4jLogger
 
+	protected val messageStore: MessageStore
+
 	def createMessageProducer(exchangeName: String): AmqpProducer = {
 		val exchangeParams = configuration.getExchangeParams(exchangeName)
 
-		new AmqpProducer(connection, actorSystem, configuration.connectionTimeOut, logger)(exchangeParams)
+		new AmqpProducer(connection, actorSystem, messageStore, configuration.connectionTimeOut, logger)(exchangeParams)
 	}
 
 	def createMessageConsumer(queueName: String): AmqpConsumer = {

--- a/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
@@ -20,7 +20,7 @@ trait AmqpClientProvider {
 	def createMessageProducer(exchangeName: String): AmqpProducer = {
 		val exchangeParams = configuration.getExchangeParams(exchangeName)
 
-		new AmqpProducer(connection, actorSystem, messageStore, configuration.connectionTimeOut, logger)(exchangeParams)
+		new AmqpProducer(connection, actorSystem, messageStore, configuration.connectionTimeOut, configuration.askTimeOut, logger)(exchangeParams)
 	}
 
 	def createMessageConsumer(queueName: String): AmqpConsumer = {

--- a/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
@@ -16,6 +16,7 @@ trait AmqpConfiguration {
 	val password = config.getString("messageQueue.password")
 	val heartbeatRate = config.getInt("messageQueue.heartbeatRate")
 	val connectionTimeOut = config.getLong("messageQueue.connectionTimeoutInSec")
+	val askTimeOut = config.getLong("messageQueue.askTimeoutInSec")
 
 	private val hosts: Seq[String] = config.getStringList("messageQueue.hosts").asScala.toSeq
 

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -1,5 +1,11 @@
 package com.kinja.amqp
 
+import java.util.UUID
+
+import com.kinja.amqp.model.MessageConfirmation
+import com.kinja.amqp.model.Message
+
+import com.github.sstone.amqp.ChannelOwner.NotConnectedError
 import com.github.sstone.amqp.ConnectionOwner
 import com.github.sstone.amqp.ChannelOwner
 import com.github.sstone.amqp.Amqp
@@ -7,8 +13,12 @@ import com.github.sstone.amqp.Amqp._
 
 import com.rabbitmq.client.AMQP.BasicProperties
 
+import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.pattern.ask
+import akka.util.Timeout
 
 import org.slf4j.{ Logger => Slf4jLogger }
 
@@ -16,9 +26,14 @@ import play.api.libs.json._
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Try
+
 class AmqpProducer(
 	connection: ActorRef,
 	actorSystem: ActorSystem,
+	messageStore: MessageStore,
 	connectionTimeOut: Long,
 	logger: Slf4jLogger)(exchange: ExchangeParameters) {
 
@@ -26,14 +41,44 @@ class AmqpProducer(
 
 	Amqp.waitForConnection(actorSystem, connection, channel).await(connectionTimeOut, TimeUnit.SECONDS)
 
-	def publish[A: Writes](routingKey: String, message: A): Unit = {
+	channel ! ConfirmSelect
+	channel ! AddConfirmListener(createConfirmListener)
+
+	def publish[A: Writes](routingKey: String, message: A, saveTimeMillis: Long = System.currentTimeMillis()): Future[Try[Unit]] = {
 		val json = Json.toJson(message)
 		val bytes = json.toString.getBytes(java.nio.charset.Charset.forName("UTF-8"))
 		val properties = new BasicProperties.Builder().deliveryMode(2).build()
-		channel ! Publish(exchange.name, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false)
+		//TODO: this should come from config
+		implicit val timeout = Timeout(5.seconds)
+		//TODO: exec context
+		import scala.concurrent.ExecutionContext.Implicits.global
+		channel ? Publish(exchange.name, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false) map { resp =>
+			resp match {
+				case ok: Ok => {
+					val data = ok.result.get.asInstanceOf[(Long, UUID)]
+					//TODO: use new key class
+					messageStore.saveMessage(Message(None, routingKey, json.toString, Some(data._2), Some(data._1), saveTimeMillis))
+				}
+				case err: NotConnectedError => messageStore.saveMessage(Message(None, routingKey, json.toString, None, None, saveTimeMillis))
+				case _ => messageStore.saveMessage(Message(None, routingKey, json.toString, None, None, saveTimeMillis))
+			}
+		} recoverWith {
+			case _ => Future(messageStore.saveMessage(Message(None, routingKey, json.toString, None, None, saveTimeMillis)))
+		}
 	}
 
 	private def createChannel(): ActorRef = {
 		ConnectionOwner.createChildActor(connection, ChannelOwner.props(init = List(Record(DeclareExchange(exchange)))))
 	}
+
+	private def createConfirmListener: ActorRef = actorSystem.actorOf(Props(new Actor {
+		def receive = {
+			case HandleAck(deliveryTag, multiple) =>
+				//TODO: publish local
+				val channelId = UUID.randomUUID()
+				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
+			case HandleNack(deliveryTag, multiple) =>
+			//TODO: log
+		}
+	}))
 }

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import com.kinja.amqp.model.MessageConfirmation
 import com.kinja.amqp.model.Message
 
-import com.github.sstone.amqp.ChannelOwner.NotConnectedError
 import com.github.sstone.amqp.ConnectionOwner
 import com.github.sstone.amqp.ChannelOwner
 import com.github.sstone.amqp.Amqp
@@ -26,9 +25,9 @@ import play.api.libs.json._
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.Try
 
 class AmqpProducer(
 	connection: ActorRef,
@@ -38,6 +37,7 @@ class AmqpProducer(
 	askTimeout: Long,
 	logger: Slf4jLogger)(exchange: ExchangeParameters) {
 
+	private implicit val timeout = Timeout(askTimeout.seconds)
 	private val channel: ActorRef = createChannel()
 
 	Amqp.waitForConnection(actorSystem, connection, channel).await(connectionTimeOut, TimeUnit.SECONDS)
@@ -45,26 +45,17 @@ class AmqpProducer(
 	channel ! ConfirmSelect
 	channel ! AddConfirmListener(createConfirmListener)
 
-	def publish[A: Writes](routingKey: String, message: A, saveTimeMillis: Long = System.currentTimeMillis()): Future[Try[Unit]] = {
+	def publish[A: Writes](routingKey: String, message: A, saveTimeMillis: Long = System.currentTimeMillis())(implicit ec: ExecutionContext): Future[Unit] = {
 		val json = Json.toJson(message)
 		val bytes = json.toString.getBytes(java.nio.charset.Charset.forName("UTF-8"))
 		val properties = new BasicProperties.Builder().deliveryMode(2).build()
-		implicit val timeout = Timeout(askTimeout.seconds)
-		import scala.concurrent.ExecutionContext.Implicits.global
-		channel ? Publish(exchange.name, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false) map { resp =>
-			resp match {
-				case ok: Ok => {
-					ok.result match {
-						case Some(MessageUniqueKey(deliveryTag, channelId)) =>
-							messageStore.saveMessage(Message(None, routingKey, json.toString, Some(channelId), Some(deliveryTag), saveTimeMillis))
-						case _ => messageStore.saveMessage(Message(None, routingKey, json.toString, None, None, saveTimeMillis))
-					}
-				}
-				case err: NotConnectedError => messageStore.saveMessage(Message(None, routingKey, json.toString, None, None, saveTimeMillis))
-				case _ => messageStore.saveMessage(Message(None, routingKey, json.toString, None, None, saveTimeMillis))
+		channel ? Publish(exchange.name, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false) map {
+			case Ok(_, Some(MessageUniqueKey(deliveryTag, channelId))) => {
+				messageStore.saveMessage(Message(None, routingKey, exchange.name, json.toString, Some(channelId), Some(deliveryTag), saveTimeMillis))
 			}
+			case _ => messageStore.saveMessage(Message(None, exchange.name, routingKey, json.toString, None, None, saveTimeMillis))
 		} recoverWith {
-			case _ => Future(messageStore.saveMessage(Message(None, routingKey, json.toString, None, None, saveTimeMillis)))
+			case _ => Future.successful(messageStore.saveMessage(Message(None, exchange.name, routingKey, json.toString, None, None, saveTimeMillis)))
 		}
 	}
 
@@ -72,12 +63,23 @@ class AmqpProducer(
 		ConnectionOwner.createChildActor(connection, ChannelOwner.props(init = List(Record(DeclareExchange(exchange)))))
 	}
 
+	private def handleConfirm(channelId: UUID, deliveryTag: Long, multiple: Boolean): Unit = {
+		if (multiple)
+			messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
+		else {
+			if (messageStore.deleteMessageUponConfirm(channelId, deliveryTag) > 0) {}
+			else
+				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
+		}
+	}
+
 	private def createConfirmListener: ActorRef = actorSystem.actorOf(Props(new Actor {
 		def receive = {
 			case HandleAck(deliveryTag, multiple, channelId) =>
-				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
-			case HandleNack(deliveryTag, multiple, channelId) => logger.warn(
-				s"""Receiving HandleNack with delivery tag: $deliveryTag,
+				handleConfirm(channelId, deliveryTag, multiple)
+			case HandleNack(deliveryTag, multiple, channelId) =>
+				logger.warn(
+					s"""Receiving HandleNack with delivery tag: $deliveryTag,
 					 | multiple: $multiple, channelId: $channelId""")
 		}
 	}))

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -78,7 +78,7 @@ class AmqpProducer(
 				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
 			case HandleNack(deliveryTag, multiple, channelId) => logger.warn(
 				s"""Receiving HandleNack with delivery tag: $deliveryTag,
-					 | multiple: $multiple, channelId: $channelId""".stripMargin)
+					 | multiple: $multiple, channelId: $channelId""")
 		}
 	}))
 }

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -1,0 +1,18 @@
+package com.kinja.amqp
+
+import java.util.UUID
+
+import com.kinja.amqp.model.Message
+import com.kinja.amqp.model.MessageConfirmation
+
+import scala.util.Try
+
+trait MessageStore {
+
+	def saveConfirmation(conf: MessageConfirmation): Unit
+	def saveMessage(msg: Message): Try[Unit]
+	def loadMessageOlderThan(time: Long): List[Message]
+	def loadConfirmationByChannels(channelIds: List[UUID]): List[MessageConfirmation]
+	def deleteMessage(channelId: UUID, deliveryTag: Long): Unit
+	def deleteConfirmation(conf: MessageConfirmation): Unit
+}

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -10,6 +10,7 @@ import scala.util.Try
 trait MessageStore {
 
 	def saveConfirmation(conf: MessageConfirmation): Unit
+	//message save is critical so all errors have to show up in the return value
 	def saveMessage(msg: Message): Try[Unit]
 	def loadMessageOlderThan(time: Long): List[Message]
 	def loadConfirmationByChannels(channelIds: List[UUID]): List[MessageConfirmation]

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -5,15 +5,25 @@ import java.util.UUID
 import com.kinja.amqp.model.Message
 import com.kinja.amqp.model.MessageConfirmation
 
-import scala.util.Try
-
 trait MessageStore {
 
+	/**
+	 * Between start and commit, the message store should make sure that
+	 * the loaded records are not updated/deleted by any other transaction.
+	 * If it can not be guaranteed AND multiple message repeater instances exist,
+	 * same repeaters may try to resend or delete the very same messages/confirmations at a given time
+	 */
+	def startTransaction(): Unit
+	def commit(): Unit
 	def saveConfirmation(conf: MessageConfirmation): Unit
-	//message save is critical so all errors have to show up in the return value
-	def saveMessage(msg: Message): Try[Unit]
-	def loadMessageOlderThan(time: Long): List[Message]
+	def saveMessage(msg: Message): Unit
+	def loadMessageOlderThan(time: Long, exchangeName: String, limit: Int): List[Message]
 	def loadConfirmationByChannels(channelIds: List[UUID]): List[MessageConfirmation]
 	def deleteMessage(id: Long): Unit
+
+	/**
+	 * Returns the number of deleted messages
+	 */
+	def deleteMessageUponConfirm(channelId: UUID, deliveryTag: Long): Int
 	def deleteConfirmation(id: Long): Unit
 }

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -13,6 +13,6 @@ trait MessageStore {
 	def saveMessage(msg: Message): Try[Unit]
 	def loadMessageOlderThan(time: Long): List[Message]
 	def loadConfirmationByChannels(channelIds: List[UUID]): List[MessageConfirmation]
-	def deleteMessage(channelId: UUID, deliveryTag: Long): Unit
+	def deleteMessage(id: Long): Unit
 	def deleteConfirmation(conf: MessageConfirmation): Unit
 }

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -14,5 +14,5 @@ trait MessageStore {
 	def loadMessageOlderThan(time: Long): List[Message]
 	def loadConfirmationByChannels(channelIds: List[UUID]): List[MessageConfirmation]
 	def deleteMessage(id: Long): Unit
-	def deleteConfirmation(conf: MessageConfirmation): Unit
+	def deleteConfirmation(id: Long): Unit
 }

--- a/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
+++ b/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
@@ -1,0 +1,70 @@
+package com.kinja.amqp
+
+import com.kinja.amqp.model.Message
+import com.kinja.amqp.model.MessageConfirmation
+
+import org.slf4j.{ Logger => Slf4jLogger }
+
+import scala.util.Failure
+import scala.util.Success
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object UnconfirmedMessageRepeater {
+
+	/**
+	 * Loads the messages from the store.
+	 * For already confirmed messages, deletes the message and the confirmation.
+	 * For unconfirmed messages, tries to republish and if succeeds, deletes old message and confirmation.
+	 */
+	def resendUnconfirmedMessages(messageStore: MessageStore, olderThan: Long, producer: AmqpProducer, logger: Slf4jLogger): Unit = {
+		val oldMessages = messageStore.loadMessageOlderThan(olderThan)
+		val channels = oldMessages.map(_.channelId).flatten
+		val relevantConfirms = messageStore.loadConfirmationByChannels(channels)
+		val (confirmed, unconfirmed) = oldMessages.partition { msg =>
+			relevantConfirms.foldRight(false)((conf, confirmed) => confirmed || isConfirmedBy(msg, conf))
+		}
+
+		confirmed.foreach(m => deleteMessageAndMatchingConfirm(m, relevantConfirms, messageStore))
+
+		resendAndDelete(unconfirmed, relevantConfirms, producer, messageStore, logger)
+
+	}
+
+	/**
+	 * Resend the messages in the list and if managed to publish, delete msg and matching confirmation from the store
+	 */
+	private def resendAndDelete(msgs: List[Message], confs: List[MessageConfirmation], producer: AmqpProducer, messageStore: MessageStore, logger: Slf4jLogger): Unit = {
+		for {
+			msg <- msgs
+			publishFut = producer.publish(msg.routingKey, msg.message)
+			_ = publishFut.map { result =>
+				result match {
+					case Success(_) => deleteMessageAndMatchingConfirm(msg, confs, messageStore)
+					case Failure(ex) => logger.warn(s"""Couldn't resend message: $msg, ${ex.getMessage}""")
+				}
+			}
+		} yield Unit
+	}
+
+	private def getMatchingConfirm(msg: Message, confs: List[MessageConfirmation]): Option[MessageConfirmation] = {
+		for {
+			channelId <- msg.channelId
+			deliveryTag <- msg.deliveryTag
+			relevantConfirm <- confs.find(c => (!c.multiple && c.channelId == channelId && c.deliveryTag == deliveryTag))
+		} yield {
+			relevantConfirm
+		}
+	}
+
+	private def deleteMessageAndMatchingConfirm(msg: Message, confs: List[MessageConfirmation], messageStore: MessageStore): Unit = {
+		messageStore.deleteMessage(msg.id.getOrElse(throw new IllegalStateException(s"""Fetched message doesn't an have id: $msg""")))
+		getMatchingConfirm(msg, confs).map(messageStore.deleteConfirmation(_))
+	}
+
+	private def isConfirmedBy(msg: Message, conf: MessageConfirmation): Boolean = {
+		msg.channelId == Some(conf.channelId) &&
+			(msg.deliveryTag == Some(conf.deliveryTag) || (conf.multiple && msg.deliveryTag.map(_ <= conf.deliveryTag).getOrElse(false)))
+	}
+
+}

--- a/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
+++ b/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
@@ -5,68 +5,92 @@ import com.kinja.amqp.model.MessageConfirmation
 
 import org.slf4j.{ Logger => Slf4jLogger }
 
+import akka.actor.ActorSystem
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 import scala.util.Failure
 import scala.util.Success
 
-import scala.concurrent.ExecutionContext.Implicits.global
+class UnconfirmedMessageRepeater(
+	actorSystem: ActorSystem,
+	messageStore: MessageStore,
+	producers: Map[String, AmqpProducer],
+	logger: Slf4jLogger) {
 
-object UnconfirmedMessageRepeater {
+	/**
+	 * Schedules message resend logic periodically
+	 * @param initialDelay The delay to start scheduling after
+	 * @param interval Interval between two scheduled actions
+	 * @param minAge The minimum age of the message to resend
+	 * @param limit The max number of messages that are processed in each iteration
+	 * @param ec Execution context used for scheduling and resend logic
+	 */
+	def startSchedule(initialDelay: FiniteDuration, interval: FiniteDuration, minAge: FiniteDuration, limit: Int)(implicit ec: ExecutionContext): Unit = {
+		actorSystem.scheduler.schedule(initialDelay, interval)(resendUnconfirmed(minAge, limit))
+	}
+
+	private def resendUnconfirmed(minAge: FiniteDuration, limit: Int)(implicit ec: ExecutionContext): Unit = {
+		producers.foreach { case (exchange, producer) => resendUnconfirmed(System.currentTimeMillis() - minAge.toMillis, limit, exchange, producer) }
+	}
 
 	/**
 	 * Loads the messages from the store.
 	 * For already confirmed messages, deletes the message and the confirmation.
 	 * For unconfirmed messages, tries to republish and if succeeds, deletes old message and confirmation.
 	 */
-	def resendUnconfirmedMessages(messageStore: MessageStore, olderThan: Long, producer: AmqpProducer, logger: Slf4jLogger): Unit = {
-		val oldMessages = messageStore.loadMessageOlderThan(olderThan)
-		val channels = oldMessages.map(_.channelId).flatten
-		val relevantConfirms = messageStore.loadConfirmationByChannels(channels)
-		val (confirmed, unconfirmed) = oldMessages.partition { msg =>
-			relevantConfirms.foldRight(false)((conf, confirmed) => confirmed || isConfirmedBy(msg, conf))
+	private def resendUnconfirmed(olderThan: Long, limit: Int, exchangeName: String, producer: AmqpProducer)(implicit ec: ExecutionContext): Unit = {
+		messageStore.startTransaction()
+		try {
+			val oldMessages = messageStore.loadMessageOlderThan(olderThan, exchangeName, limit)
+			val channels = oldMessages.map(_.channelId).flatten
+			val relevantConfirms = messageStore.loadConfirmationByChannels(channels)
+			val (confirmed, unconfirmed) = oldMessages.partition { msg =>
+				relevantConfirms.exists(c => isConfirmedBy(msg, c))
+			}
+
+			confirmed.foreach(m => deleteMessageAndMatchingConfirm(m, relevantConfirms))
+
+			resendAndDelete(unconfirmed, relevantConfirms, producer)
+		} finally {
+			messageStore.commit()
 		}
-
-		confirmed.foreach(m => deleteMessageAndMatchingConfirm(m, relevantConfirms, messageStore))
-
-		resendAndDelete(unconfirmed, relevantConfirms, producer, messageStore, logger)
 
 	}
 
 	/**
 	 * Resend the messages in the list and if managed to publish, delete msg and matching confirmation from the store
 	 */
-	private def resendAndDelete(msgs: List[Message], confs: List[MessageConfirmation], producer: AmqpProducer, messageStore: MessageStore, logger: Slf4jLogger): Unit = {
+	private def resendAndDelete(msgs: List[Message], confs: List[MessageConfirmation], producer: AmqpProducer)(implicit ec: ExecutionContext): Unit = {
 		for {
 			msg <- msgs
 			publishFut = producer.publish(msg.routingKey, msg.message)
-			_ = publishFut.map { result =>
-				result match {
-					case Success(_) => deleteMessageAndMatchingConfirm(msg, confs, messageStore)
-					case Failure(ex) => logger.warn(s"""Couldn't resend message: $msg, ${ex.getMessage}""")
-				}
-			}
-		} yield Unit
+		} yield publishFut.onComplete {
+			case Success(_) => deleteMessageAndMatchingConfirm(msg, confs)
+			case Failure(ex) => logger.warn(s"""Couldn't resend message: $msg, ${ex.getMessage}""")
+		}
 	}
 
 	private def getMatchingConfirm(msg: Message, confs: List[MessageConfirmation]): Option[MessageConfirmation] = {
 		for {
 			channelId <- msg.channelId
 			deliveryTag <- msg.deliveryTag
-			relevantConfirm <- confs.find(c => (!c.multiple && c.channelId == channelId && c.deliveryTag == deliveryTag))
+			relevantConfirm <- confs.find(c => !c.multiple && c.channelId == channelId && c.deliveryTag == deliveryTag)
 		} yield {
 			relevantConfirm
 		}
 	}
 
-	private def deleteMessageAndMatchingConfirm(msg: Message, confs: List[MessageConfirmation], messageStore: MessageStore): Unit = {
+	private def deleteMessageAndMatchingConfirm(msg: Message, confs: List[MessageConfirmation]): Unit = {
 		messageStore.deleteMessage(msg.id.getOrElse(throw new IllegalStateException(s"""Fetched message doesn't an have id: $msg""")))
-		getMatchingConfirm(msg, confs).map { c =>
+		getMatchingConfirm(msg, confs).foreach { c =>
 			messageStore.deleteConfirmation(c.id.getOrElse(throw new IllegalStateException(s"""Fetched confirmation doesn't an have id: $c""")))
 		}
 	}
 
 	private def isConfirmedBy(msg: Message, conf: MessageConfirmation): Boolean = {
 		msg.channelId == Some(conf.channelId) &&
-			(msg.deliveryTag == Some(conf.deliveryTag) || (conf.multiple && msg.deliveryTag.map(_ <= conf.deliveryTag).getOrElse(false)))
+			(msg.deliveryTag == Some(conf.deliveryTag) || (conf.multiple && msg.deliveryTag.exists(_ <= conf.deliveryTag)))
 	}
 
 }

--- a/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
+++ b/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
@@ -59,7 +59,9 @@ object UnconfirmedMessageRepeater {
 
 	private def deleteMessageAndMatchingConfirm(msg: Message, confs: List[MessageConfirmation], messageStore: MessageStore): Unit = {
 		messageStore.deleteMessage(msg.id.getOrElse(throw new IllegalStateException(s"""Fetched message doesn't an have id: $msg""")))
-		getMatchingConfirm(msg, confs).map(messageStore.deleteConfirmation(_))
+		getMatchingConfirm(msg, confs).map { c =>
+			messageStore.deleteConfirmation(c.id.getOrElse(throw new IllegalStateException(s"""Fetched confirmation doesn't an have id: $c""")))
+		}
 	}
 
 	private def isConfirmedBy(msg: Message, conf: MessageConfirmation): Boolean = {

--- a/src/main/scala/com/kinja/amqp/model/Message.scala
+++ b/src/main/scala/com/kinja/amqp/model/Message.scala
@@ -1,0 +1,11 @@
+package com.kinja.amqp.model
+
+import java.util.UUID
+
+case class Message(
+	id: Option[Long],
+	routingKey: String,
+	message: String,
+	channelId: Option[UUID],
+	deliveryTag: Option[Long],
+	createdTime: Long)

--- a/src/main/scala/com/kinja/amqp/model/Message.scala
+++ b/src/main/scala/com/kinja/amqp/model/Message.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 case class Message(
 	id: Option[Long],
 	routingKey: String,
+	exchangeName: String,
 	message: String,
 	channelId: Option[UUID],
 	deliveryTag: Option[Long],

--- a/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
+++ b/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
@@ -1,0 +1,9 @@
+package com.kinja.amqp.model
+
+import java.util.UUID
+
+case class MessageConfirmation(
+	id: Option[Long],
+	channelId: UUID,
+	deliveryTag: Long,
+	multiple: Boolean)


### PR DESCRIPTION
### What does this PR do? How does it affect users?

Add confirmation logic to the amqp producer.

Open questions:
- what should trigger the resend logic implemented in UnconfirmedMessageRepeater?
- what execution context to use when mapping saves/deletes to previously fired actions?
### How should this be tested (feature switches, URLs, special user permissions)?

Going to PR the mysql backed MessageStore implementation soon. With that and tables created in dev environment, it can be tested.
### Related Trello card, wiki page or blog posts

https://trello.com/c/Il7iSgAt/323-configure-and-use-rabbitmq-in-linksupportservice

This change depends on:
https://github.com/gawkermedia/amqp-client/pull/1/files

@privateblue @stratiator could you please check?
