### PR TITLE
update scalariform to a mantained fork, format really long lines

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,5 +28,6 @@ publishTo <<= (version)(version =>
 scalariformSettings
 
 // code formatting
-ScalariformKeys.preferences := scalariform.formatter.preferences.FormattingPreferences().
-    setPreference(scalariform.formatter.preferences.IndentWithTabs, true)
+ScalariformKeys.preferences := scalariform.formatter.preferences.FormattingPreferences()
+    .setPreference(scalariform.formatter.preferences.IndentWithTabs, true)
+    .setPreference(scalariform.formatter.preferences.PreserveDanglingCloseParenthesis, true)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "amqp-client-provider"
 
 organization := "com.kinja"
 
-version := "0.0.4" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.1.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 scalaVersion := "2.10.3"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ resolvers += "Gawker Public Group" at "https://nexus.kinja-ops.com/nexus/content
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")
+addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.3.0")

--- a/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
@@ -32,7 +32,14 @@ trait AmqpClientProvider {
 	private def createProducers(): Map[String, AmqpProducer] = {
 		configuration.exchanges.map {
 			case (name: String, params: ExchangeParameters) =>
-				name -> new AmqpProducer(connection, actorSystem, messageStore, configuration.connectionTimeOut, configuration.askTimeOut, logger)(params)
+				name -> new AmqpProducer(
+					connection,
+					actorSystem,
+					messageStore,
+					configuration.connectionTimeOut,
+					configuration.askTimeOut,
+					logger
+				)(params)
 		}
 	}
 

--- a/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
@@ -43,7 +43,8 @@ trait AmqpConfiguration {
 			val boundExchangeName = queueConfig.getString("exchange")
 
 			val boundExchangeParams: ExchangeParameters = exchanges.getOrElse(
-				boundExchangeName, throw new Missing(s"messageQueue.exchanges.$boundExchangeName"))
+				boundExchangeName, throw new Missing(s"messageQueue.exchanges.$boundExchangeName")
+			)
 
 			val routingKey = queueConfig.getString("routingKey")
 
@@ -54,15 +55,19 @@ trait AmqpConfiguration {
 			}
 
 			val deadLetterExchangeParams: Option[ExchangeParameters] = deadLetterExchangeName.map(
-				exchanges.getOrElse(_, throw new Missing(s"messageQueue.queues.$name.exchange")))
+				exchanges.getOrElse(_, throw new Missing(s"messageQueue.queues.$name.exchange"))
+			)
 
 			val additionalParams: Map[String, String] = deadLetterExchangeName
 				.map(name => Map("x-dead-letter-exchange" -> name)).getOrElse(Map.empty)
 
 			val queueParameters = QueueParameters(
-				name, passive = false, durable = true, exclusive = false, autodelete = false, additionalParams)
+				name, passive = false, durable = true, exclusive = false, autodelete = false, additionalParams
+			)
 
-			name -> QueueWithRelatedParameters(queueParameters, boundExchangeParams, deadLetterExchangeParams, routingKey)
+			name -> QueueWithRelatedParameters(
+				queueParameters, boundExchangeParams, deadLetterExchangeParams, routingKey
+			)
 		}.toMap
 	}
 
@@ -90,6 +95,7 @@ trait AmqpConfiguration {
 			"amq.direct" -> StandardExchanges.amqDirect,
 			"amq.fanout" -> StandardExchanges.amqFanout,
 			"amq.headers" -> StandardExchanges.amqHeaders,
-			"amq.match" -> StandardExchanges.amqMatch)
+			"amq.match" -> StandardExchanges.amqMatch
+		)
 	}
 }


### PR DESCRIPTION
### What does this PR do? How does it affect users?

Updated scalariform plugin to a maintained fork as the original one wasn't updated in two years. The new one will work with scala 2.11, and has some fixes about `PreserveDanglingCloseParenthesis` (which is turned on by default), and some more. As the sbt-scalariform plugin used the original scalariform, I included the fork from the same maintainer to use the new one.
https://github.com/daniel-trinh/scalariform
https://github.com/daniel-trinh/sbt-scalariform

Enabled `PreserveDanglingCloseParenthesis` (which is turned on for multiline expressions by default and cannot be turned off, just wanted to be more verbose.
Reformatted really long lines.
### How should this be tested (feature switches, URLs, special user permissions)?

If it compiles, it works.

@leventem Can you check please? cc @privateblue 
![](https://media0.giphy.com/media/od6hnmsAnvhrW/200.gif)
