### PR TITLE
Compute resender result in a by-name parameter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scalacOptions  ++= Seq("-feature", "-language:postfixOps")
 shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project + "> " }
 
 libraryDependencies ++= Seq(
-    "com.kinja" %% "amqp-client" % "1.5.0-SNAPSHOT",
+    "com.kinja" %% "amqp-client" % "1.5.0",
     "com.typesafe.play" %% "play-json" % "2.3.4"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "amqp-client-provider"
 
 organization := "com.kinja"
 
-version := "0.1.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.3.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 scalaVersion := "2.10.3"
 
@@ -11,7 +11,7 @@ scalacOptions  ++= Seq("-feature", "-language:postfixOps")
 shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project + "> " }
 
 libraryDependencies ++= Seq(
-    "com.kinja" %% "amqp-client" % "1.4.1-SNAPSHOT",
+    "com.kinja" %% "amqp-client" % "1.5.0-SNAPSHOT",
     "com.typesafe.play" %% "play-json" % "2.3.4"
 )
 

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -73,22 +73,22 @@ class AmqpProducer(
 	}
 
 	private def handleConfirm(
-		channelId: String, deliveryTag: Long, multiple: Boolean
+		channelId: String, deliveryTag: Long, multiple: Boolean, timestamp: Long
 	): Unit = {
 		if (multiple)
-			messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
+			messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple, timestamp))
 		else {
 			if (messageStore.deleteMessageUponConfirm(channelId, deliveryTag) > 0) {}
 			else
-				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
+				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple, timestamp))
 		}
 	}
 
 	private def createConfirmListener: ActorRef = actorSystem.actorOf(Props(new Actor {
 		def receive = {
-			case HandleAck(deliveryTag, multiple, channelId) =>
+			case HandleAck(deliveryTag, multiple, channelId, timestamp) =>
 				handleConfirm(channelId, deliveryTag, multiple)
-			case HandleNack(deliveryTag, multiple, channelId) =>
+			case HandleNack(deliveryTag, multiple, channelId, timestamp) =>
 				logger.warn(
 					s"""Receiving HandleNack with delivery tag: $deliveryTag,
 					 | multiple: $multiple, channelId: $channelId"""

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -1,7 +1,5 @@
 package com.kinja.amqp
 
-import java.util.UUID
-
 import com.kinja.amqp.model.MessageConfirmation
 import com.kinja.amqp.model.Message
 
@@ -50,7 +48,7 @@ class AmqpProducer(
 		channel ? Publish(exchange.name, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false) map {
 			case Ok(_, Some(MessageUniqueKey(deliveryTag, channelId))) => {
 				messageStore.saveMessage(
-					Message(None, routingKey, exchange.name, json.toString, Some(channelId.toString), Some(deliveryTag), saveTimeMillis)
+					Message(None, routingKey, exchange.name, json.toString, Some(channelId), Some(deliveryTag), saveTimeMillis)
 				)
 			}
 			case _ => messageStore.saveMessage(Message(None, exchange.name, routingKey, json.toString, None, None, saveTimeMillis))
@@ -75,14 +73,14 @@ class AmqpProducer(
 	}
 
 	private def handleConfirm(
-		channelId: UUID, deliveryTag: Long, multiple: Boolean
+		channelId: String, deliveryTag: Long, multiple: Boolean
 	): Unit = {
 		if (multiple)
-			messageStore.saveConfirmation(MessageConfirmation(None, channelId.toString, deliveryTag, multiple))
+			messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
 		else {
-			if (messageStore.deleteMessageUponConfirm(channelId.toString, deliveryTag) > 0) {}
+			if (messageStore.deleteMessageUponConfirm(channelId, deliveryTag) > 0) {}
 			else
-				messageStore.saveConfirmation(MessageConfirmation(None, channelId.toString, deliveryTag, multiple))
+				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
 		}
 	}
 

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -49,13 +49,13 @@ class AmqpProducer(
 		channel ? Publish(exchange.name, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false) map {
 			case Ok(_, Some(MessageUniqueKey(deliveryTag, channelId))) => {
 				messageStore.saveMessage(
-					Message(None, routingKey, exchange.name, json.toString, Some(channelId), Some(deliveryTag), saveTimeMillis)
+					Message(None, routingKey, exchange.name, json.toString, Some(channelId), Some(deliveryTag), new Date(saveTimeMillis))
 				)
 			}
-			case _ => messageStore.saveMessage(Message(None, exchange.name, routingKey, json.toString, None, None, saveTimeMillis))
+			case _ => messageStore.saveMessage(Message(None, routingKey, exchange.name, json.toString, None, None, new Date(saveTimeMillis)))
 		} recoverWith {
 			case _ => Future.successful(
-				messageStore.saveMessage(Message(None, exchange.name, routingKey, json.toString, None, None, saveTimeMillis))
+				messageStore.saveMessage(Message(None, routingKey, exchange.name, json.toString, None, None, new Date(saveTimeMillis)))
 			)
 		}
 	}

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -50,7 +50,7 @@ class AmqpProducer(
 		channel ? Publish(exchange.name, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false) map {
 			case Ok(_, Some(MessageUniqueKey(deliveryTag, channelId))) => {
 				messageStore.saveMessage(
-					Message(None, routingKey, exchange.name, json.toString, Some(channelId), Some(deliveryTag), saveTimeMillis)
+					Message(None, routingKey, exchange.name, json.toString, Some(channelId.toString), Some(deliveryTag), saveTimeMillis)
 				)
 			}
 			case _ => messageStore.saveMessage(Message(None, exchange.name, routingKey, json.toString, None, None, saveTimeMillis))
@@ -78,11 +78,11 @@ class AmqpProducer(
 		channelId: UUID, deliveryTag: Long, multiple: Boolean
 	): Unit = {
 		if (multiple)
-			messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
+			messageStore.saveConfirmation(MessageConfirmation(None, channelId.toString, deliveryTag, multiple))
 		else {
-			if (messageStore.deleteMessageUponConfirm(channelId, deliveryTag) > 0) {}
+			if (messageStore.deleteMessageUponConfirm(channelId.toString, deliveryTag) > 0) {}
 			else
-				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple))
+				messageStore.saveConfirmation(MessageConfirmation(None, channelId.toString, deliveryTag, multiple))
 		}
 	}
 

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -1,29 +1,44 @@
 package com.kinja.amqp
 
-import java.util.UUID
-
 import com.kinja.amqp.model.Message
 import com.kinja.amqp.model.MessageConfirmation
 
 trait MessageStore {
 
-	/**
-	 * Between start and commit, the message store should make sure that
-	 * the loaded records are not updated/deleted by any other transaction.
-	 * If it can not be guaranteed AND multiple message repeater instances exist,
-	 * same repeaters may try to resend or delete the very same messages/confirmations at a given time
-	 */
-	def startTransaction(): Unit
-	def commit(): Unit
 	def saveConfirmation(conf: MessageConfirmation): Unit
 	def saveMessage(msg: Message): Unit
-	def loadMessageOlderThan(time: Long, exchangeName: String, limit: Int): List[Message]
-	def loadConfirmationByChannels(channelIds: List[String]): List[MessageConfirmation]
-	def deleteMessage(id: Long): Unit
 
 	/**
 	 * Returns the number of deleted messages
 	 */
 	def deleteMessageUponConfirm(channelId: String, deliveryTag: Long): Int
+
+	/**
+	 * Within this method, the message store should make sure that
+	 * the loaded records are not updated/deleted by any other transaction.
+	 * If it can not be guaranteed AND multiple message repeater instances exist,
+	 * same repeaters may try to resend or delete the very same messages/confirmations at a given time
+	 */
+	def withLockingTransaction[T](f: => T): T
+
+	/**
+	 * Used in withLockingTransaction
+	 */
+	def loadMessageOlderThan(time: Long, exchangeName: String, limit: Int): List[Message]
+
+	/**
+	 * Used in withLockingTransaction
+	 */
+	def loadConfirmationByChannels(channelIds: List[String]): List[MessageConfirmation]
+
+	/**
+	 * Used in withLockingTransaction
+	 */
+	def deleteMessage(id: Long): Unit
+
+	/**
+	 * Used in withLockingTransaction
+	 */
 	def deleteConfirmation(id: Long): Unit
+
 }

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -13,32 +13,6 @@ trait MessageStore {
 	 */
 	def deleteMessageUponConfirm(channelId: String, deliveryTag: Long): Int
 
-	/**
-	 * Within this method, the message store should make sure that
-	 * the loaded records are not updated/deleted by any other transaction.
-	 * If it can not be guaranteed AND multiple message repeater instances exist,
-	 * same repeaters may try to resend or delete the very same messages/confirmations at a given time
-	 */
-	def withLockingTransaction[T](f: => T): T
-
-	/**
-	 * Used in withLockingTransaction
-	 */
-	def loadMessageOlderThan(time: Long, exchangeName: String, limit: Int): List[Message]
-
-	/**
-	 * Used in withLockingTransaction
-	 */
-	def loadConfirmationByChannels(channelIds: List[String]): List[MessageConfirmation]
-
-	/**
-	 * Used in withLockingTransaction
-	 */
-	def deleteMessage(id: Long): Unit
-
-	/**
-	 * Used in withLockingTransaction
-	 */
-	def deleteConfirmation(id: Long): Unit
+	def createTransactionalStore: TransactionalMessageStore
 
 }

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -18,12 +18,12 @@ trait MessageStore {
 	def saveConfirmation(conf: MessageConfirmation): Unit
 	def saveMessage(msg: Message): Unit
 	def loadMessageOlderThan(time: Long, exchangeName: String, limit: Int): List[Message]
-	def loadConfirmationByChannels(channelIds: List[UUID]): List[MessageConfirmation]
+	def loadConfirmationByChannels(channelIds: List[String]): List[MessageConfirmation]
 	def deleteMessage(id: Long): Unit
 
 	/**
 	 * Returns the number of deleted messages
 	 */
-	def deleteMessageUponConfirm(channelId: UUID, deliveryTag: Long): Int
+	def deleteMessageUponConfirm(channelId: String, deliveryTag: Long): Int
 	def deleteConfirmation(id: Long): Unit
 }

--- a/src/main/scala/com/kinja/amqp/TransactionalMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/TransactionalMessageStore.scala
@@ -1,0 +1,25 @@
+package com.kinja.amqp
+
+import com.kinja.amqp.model.Message
+import com.kinja.amqp.model.MessageConfirmation
+
+/**
+ * The TransactionalMessageStore should make sure that
+ * the loaded records between start and commit are not updated/deleted by any other transaction.
+ * If it can not be guaranteed AND multiple message repeater instances exist,
+ * same repeaters may try to resend or delete the very same messages/confirmations at a given time
+ */
+trait TransactionalMessageStore {
+
+	def start: Unit
+
+	def commit: Unit
+
+	def loadMessageOlderThan(time: Long, exchangeName: String, limit: Int): List[Message]
+
+	def loadConfirmationByChannels(channelIds: List[String]): List[MessageConfirmation]
+
+	def deleteMessage(id: Long): Unit
+
+	def deleteConfirmation(id: Long): Unit
+}

--- a/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
+++ b/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
@@ -48,31 +48,33 @@ class UnconfirmedMessageRepeater(
 	private def resendUnconfirmed(
 		olderThan: Long, limit: Int, exchangeName: String, producer: AmqpProducer
 	)(implicit ec: ExecutionContext): Unit = {
-		messageStore.withLockingTransaction {
-			val oldMessages = messageStore.loadMessageOlderThan(olderThan, exchangeName, limit)
+		val transactional = messageStore.createTransactionalStore
+		transactional.start
+		try {
+			val oldMessages = transactional.loadMessageOlderThan(olderThan, exchangeName, limit)
 			val channels = oldMessages.map(_.channelId).flatten
-			val relevantConfirms = messageStore.loadConfirmationByChannels(channels)
+			val relevantConfirms = transactional.loadConfirmationByChannels(channels)
 			val (confirmed, unconfirmed) = oldMessages.partition { msg =>
 				relevantConfirms.exists(c => isConfirmedBy(msg, c))
 			}
 
-			confirmed.foreach(m => deleteMessageAndMatchingConfirm(m, relevantConfirms))
+			confirmed.foreach(m => deleteMessageAndMatchingConfirm(m, relevantConfirms, transactional))
 
-			resendAndDelete(unconfirmed, relevantConfirms, producer)
-		}
+			resendAndDelete(unconfirmed, relevantConfirms, producer, transactional)
+		} finally { transactional.commit }
 	}
 
 	/**
 	 * Resend the messages in the list and if managed to publish, delete msg and matching confirmation from the store
 	 */
 	private def resendAndDelete(
-		msgs: List[Message], confs: List[MessageConfirmation], producer: AmqpProducer
+		msgs: List[Message], confs: List[MessageConfirmation], producer: AmqpProducer, transactional: TransactionalMessageStore
 	)(implicit ec: ExecutionContext): Unit = {
 		for {
 			msg <- msgs
 			publishFut = producer.publish(msg.routingKey, msg.message)
 		} yield publishFut.onComplete {
-			case Success(_) => deleteMessageAndMatchingConfirm(msg, confs)
+			case Success(_) => deleteMessageAndMatchingConfirm(msg, confs, transactional)
 			case Failure(ex) => logger.warn(s"""Couldn't resend message: $msg, ${ex.getMessage}""")
 		}
 	}
@@ -87,12 +89,12 @@ class UnconfirmedMessageRepeater(
 		}
 	}
 
-	private def deleteMessageAndMatchingConfirm(msg: Message, confs: List[MessageConfirmation]): Unit = {
-		messageStore.deleteMessage(
+	private def deleteMessageAndMatchingConfirm(msg: Message, confs: List[MessageConfirmation], transactional: TransactionalMessageStore): Unit = {
+		transactional.deleteMessage(
 			msg.id.getOrElse(throw new IllegalStateException(s"""Fetched message doesn't an have id: $msg"""))
 		)
 		getMatchingConfirm(msg, confs).foreach { c =>
-			messageStore.deleteConfirmation(
+			transactional.deleteConfirmation(
 				c.id.getOrElse(throw new IllegalStateException(s"""Fetched confirmation doesn't an have id: $c"""))
 			)
 		}

--- a/src/main/scala/com/kinja/amqp/model/Message.scala
+++ b/src/main/scala/com/kinja/amqp/model/Message.scala
@@ -1,5 +1,7 @@
 package com.kinja.amqp.model
 
+import java.util.Date
+
 case class Message(
 	id: Option[Long],
 	routingKey: String,
@@ -7,5 +9,5 @@ case class Message(
 	message: String,
 	channelId: Option[String],
 	deliveryTag: Option[Long],
-	createdTime: Long
+	createdTime: Date
 )

--- a/src/main/scala/com/kinja/amqp/model/Message.scala
+++ b/src/main/scala/com/kinja/amqp/model/Message.scala
@@ -1,12 +1,11 @@
 package com.kinja.amqp.model
 
-import java.util.UUID
-
 case class Message(
 	id: Option[Long],
 	routingKey: String,
 	exchangeName: String,
 	message: String,
-	channelId: Option[UUID],
+	channelId: Option[String],
 	deliveryTag: Option[Long],
-	createdTime: Long)
+	createdTime: Long
+)

--- a/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
+++ b/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
@@ -1,9 +1,11 @@
 package com.kinja.amqp.model
 
+import java.util.Date
+
 case class MessageConfirmation(
 	id: Option[Long],
 	channelId: String,
 	deliveryTag: Long,
 	multiple: Boolean,
-	createdTime: Long
+	createdTime: Date
 )

--- a/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
+++ b/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
@@ -1,9 +1,8 @@
 package com.kinja.amqp.model
 
-import java.util.UUID
-
 case class MessageConfirmation(
 	id: Option[Long],
-	channelId: UUID,
+	channelId: String,
 	deliveryTag: Long,
-	multiple: Boolean)
+	multiple: Boolean
+)

--- a/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
+++ b/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
@@ -4,5 +4,6 @@ case class MessageConfirmation(
 	id: Option[Long],
 	channelId: String,
 	deliveryTag: Long,
-	multiple: Boolean
+	multiple: Boolean,
+	createdTime: Long
 )


### PR DESCRIPTION
### What does this PR do? How does it affect users?
1. store channelId as String instead of UUID. This makes the implementation of the db layer more easy. We can even discuss this trade-off: by storing id in a string/varchar(36), we lose some performance on the db side, but it's easier to handle in queries. By storing this in UUID/BINARY(16), it would have better performance but we should do some transformation between the db and the app layer.
2. Pass load-compute-delete part by name in message resender so it's easier to put it in a single transaction on the implementation side. For now, it's only marked in a comment that e.g. deleteMessage should be called within this by-name context. Please let me know if it should be expressed more explicitly by types.
### How should this be tested (feature switches, URLs, special user permissions)?

It can be tested once the core part is implemented.

@stratiator, @privateblue could you please check?

provider part of:
https://github.com/gawkermedia/kinja-service/pull/1261
and 
https://github.com/gawkermedia/amqp-client/pull/2/files

(Before merge, I will need to bump the version number appropriately.)
