### PR TITLE
update provider pattern to support one instance per producer/consumer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "amqp-client-provider"
 
 organization := "com.kinja"
 
-version := "0.1.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.2.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 scalaVersion := "2.10.3"
 

--- a/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientProvider.scala
@@ -1,52 +1,5 @@
 package com.kinja.amqp
 
-import akka.actor.{ ActorRef, ActorSystem }
-import com.github.sstone.amqp.Amqp.ExchangeParameters
-import com.kinja.amqp.exception.{ MissingConsumerException, MissingProducerException }
-import org.slf4j.{ Logger => Slf4jLogger }
-
 trait AmqpClientProvider {
-
-	protected val connection: ActorRef
-
-	val actorSystem: ActorSystem
-
-	protected val configuration: AmqpConfiguration
-
-	protected val logger: Slf4jLogger
-
-	protected val messageStore: MessageStore
-
-	val producers: Map[String, AmqpProducer] = createProducers()
-
-	val consumers: Map[String, AmqpConsumer] = createConsumers()
-
-	def getMessageProducer(exchangeName: String): AmqpProducer = {
-		producers.getOrElse(exchangeName, throw new MissingProducerException(exchangeName))
-	}
-
-	def getMessageConsumer(queueName: String): AmqpConsumer = {
-		consumers.getOrElse(queueName, throw new MissingConsumerException(queueName))
-	}
-
-	private def createProducers(): Map[String, AmqpProducer] = {
-		configuration.exchanges.map {
-			case (name: String, params: ExchangeParameters) =>
-				name -> new AmqpProducer(
-					connection,
-					actorSystem,
-					messageStore,
-					configuration.connectionTimeOut,
-					configuration.askTimeOut,
-					logger
-				)(params)
-		}
-	}
-
-	private def createConsumers(): Map[String, AmqpConsumer] = {
-		configuration.queues.map {
-			case (name: String, params: QueueWithRelatedParameters) =>
-				name -> new AmqpConsumer(connection, actorSystem, configuration.connectionTimeOut, logger)(params)
-		}
-	}
+	val amqpClientRegistry: AmqpClientRegistry
 }

--- a/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
@@ -1,0 +1,52 @@
+package com.kinja.amqp
+
+import akka.actor.{ ActorRef, ActorSystem }
+import com.github.sstone.amqp.Amqp.ExchangeParameters
+import com.kinja.amqp.exception.{ MissingConsumerException, MissingProducerException }
+import org.slf4j.{ Logger => Slf4jLogger }
+
+trait AmqpClientRegistry {
+
+	protected val connection: ActorRef
+
+	val actorSystem: ActorSystem
+
+	protected val configuration: AmqpConfiguration
+
+	protected val logger: Slf4jLogger
+
+	protected val messageStore: MessageStore
+
+	val producers: Map[String, AmqpProducer] = createProducers()
+
+	val consumers: Map[String, AmqpConsumer] = createConsumers()
+
+	def getMessageProducer(exchangeName: String): AmqpProducer = {
+		producers.getOrElse(exchangeName, throw new MissingProducerException(exchangeName))
+	}
+
+	def getMessageConsumer(queueName: String): AmqpConsumer = {
+		consumers.getOrElse(queueName, throw new MissingConsumerException(queueName))
+	}
+
+	private def createProducers(): Map[String, AmqpProducer] = {
+		configuration.exchanges.map {
+			case (name: String, params: ExchangeParameters) =>
+				name -> new AmqpProducer(
+					connection,
+					actorSystem,
+					messageStore,
+					configuration.connectionTimeOut,
+					configuration.askTimeOut,
+					logger
+				)(params)
+		}
+	}
+
+	private def createConsumers(): Map[String, AmqpConsumer] = {
+		configuration.queues.map {
+			case (name: String, params: QueueWithRelatedParameters) =>
+				name -> new AmqpConsumer(connection, actorSystem, configuration.connectionTimeOut, logger)(params)
+		}
+	}
+}


### PR DESCRIPTION
The original purpose with creating previous `AmqpClientProvider` with precreating all producers/consumers is that we can have exactly one instance per producer and consumer. It wasn't achieved, because with `ProductionAmqpClientProvider` being a trait creates a new set of clients with every service we use it with. See service/core parts later on the solution about having an object of ProductionAmqpClientRegistry, and a provider trait uses that object.

@leventem Can you check please? cc @privateblue 

![](https://media0.giphy.com/media/AA0Ywk64ZUBdS/200.gif)
