### PR TITLE
Delete multiple confirmations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "amqp-client-provider"
 
 organization := "com.kinja"
 
-version := "0.4.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.5.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 scalaVersion := "2.10.3"
 

--- a/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
@@ -35,7 +35,7 @@ trait AmqpClientRegistry {
 		val conf = configuration.resendConfig.getOrElse(throw new MissingResendConfigException)
 		val repeater = new UnconfirmedMessageRepeater(actorSystem, messageStore, producers, logger)
 
-		repeater.startSchedule(conf.initialDelayInSec, conf.interval, conf.minAge, conf.republishTimeoutInSec, conf.messageBatchSize)(ec)
+		repeater.startSchedule(conf.initialDelayInSec, conf.interval, conf.minMsgAge, conf.minMultiConfAge, conf.republishTimeoutInSec, conf.messageBatchSize)(ec)
 	}
 
 	private def createProducers(): Map[String, AmqpProducer] = {

--- a/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
@@ -33,9 +33,9 @@ trait AmqpClientRegistry {
 
 	def startMessageRepeater()(implicit ec: ExecutionContext) = {
 		val conf = configuration.resendConfig.getOrElse(throw new MissingResendConfigException)
-		val repeater = new UnconfirmedMessageRepeater(actorSystem, messageStore, producers, logger, conf.republishTimeoutInSec)
+		val repeater = new UnconfirmedMessageRepeater(actorSystem, messageStore, producers, logger)
 
-		repeater.startSchedule(conf.initialDelayInSec, conf.interval, conf.minAge, conf.messageBatchSize)(ec)
+		repeater.startSchedule(conf.initialDelayInSec, conf.interval, conf.minAge, conf.republishTimeoutInSec, conf.messageBatchSize)(ec)
 	}
 
 	private def createProducers(): Map[String, AmqpProducer] = {

--- a/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
@@ -15,7 +15,8 @@ case class ResendLoopConfig(
 		republishTimeoutInSec: FiniteDuration,
 		initialDelayInSec: FiniteDuration,
 		interval: FiniteDuration,
-		minAge: FiniteDuration,
+		minMsgAge: FiniteDuration,
+		minMultiConfAge: FiniteDuration,
 		messageBatchSize: Int)
 
 trait AmqpConfiguration {
@@ -42,10 +43,11 @@ trait AmqpConfiguration {
 			val republishTimeout = config.getLong("messageQueue.resendLoop.republishTimeoutInSec").seconds
 			val initialDelay = config.getLong("messageQueue.resendLoop.initialDelayInSec").seconds
 			val interval = config.getLong("messageQueue.resendLoop.intervalInSec").seconds
-			val minAge = config.getLong("messageQueue.resendLoop.minAgeInSec").seconds
+			val minMsgAge = config.getLong("messageQueue.resendLoop.minMsgAgeInSec").seconds
+			val minMultiConfAge = config.getLong("messageQueue.resendLoop.minMultiConfAgeInSec").seconds
 			val messageBatchSize = config.getInt("messageQueue.resendLoop.messageBatchSize")
 
-			Some(ResendLoopConfig(republishTimeout, initialDelay, interval, minAge, messageBatchSize))
+			Some(ResendLoopConfig(republishTimeout, initialDelay, interval, minMsgAge, minMultiConfAge, messageBatchSize))
 		} catch {
 			case NonFatal(e) => None
 		}

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -15,4 +15,6 @@ trait MessageStore {
 
 	def createTransactionalStore: TransactionalMessageStore
 
+	def deleteMultiConfIfNoMatchingMsg(olderThan: Long): Unit
+
 }

--- a/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
+++ b/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
@@ -29,6 +29,7 @@ class UnconfirmedMessageRepeater(
 	 * @param initialDelay The delay to start scheduling after
 	 * @param interval Interval between two scheduled actions
 	 * @param minMsgAge The minimum age of the message to resend
+	 * @param minMultiConfAge The min age of the confirmations for multiple msgs to check for deletion
 	 * @param republishTimeout The timeout which we can wait when republishing the msg
 	 * @param limit The max number of messages that are processed in each iteration
 	 * @param ec Execution context used for scheduling and resend logic
@@ -69,8 +70,8 @@ class UnconfirmedMessageRepeater(
 
 			resendAndDelete(unconfirmed, relevantConfirms, producer, transactional, republishTimeout)
 		} catch {
-      case e: SQLException => logger.warn(s"SQL exception while resending message: $e")
-    } finally { transactional.commit }
+			case e: SQLException => logger.warn(s"SQL exception while resending message: $e")
+		} finally { transactional.commit }
 		try {
 			messageStore.deleteMultiConfIfNoMatchingMsg(confOlderThan)
 		} catch {

--- a/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
+++ b/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
@@ -36,10 +36,10 @@ class UnconfirmedMessageRepeater(
 	 */
 	def startSchedule(
 		initialDelay: FiniteDuration,
-    interval: FiniteDuration,
-    minMsgAge: FiniteDuration,
-    minMultiConfAge: FiniteDuration,
-    republishTimeout: FiniteDuration,
+		interval: FiniteDuration,
+		minMsgAge: FiniteDuration,
+		minMultiConfAge: FiniteDuration,
+		republishTimeout: FiniteDuration,
 		limit: Int
 	)(implicit ec: ExecutionContext): Unit = {
 		actorSystem.scheduler.schedule(initialDelay, interval)(resendUnconfirmed(minMsgAge, minMultiConfAge, republishTimeout, limit))

--- a/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
+++ b/src/main/scala/com/kinja/amqp/UnconfirmedMessageRepeater.scala
@@ -35,12 +35,21 @@ class UnconfirmedMessageRepeater(
 	 * @param ec Execution context used for scheduling and resend logic
 	 */
 	def startSchedule(
-		initialDelay: FiniteDuration, interval: FiniteDuration, minMsgAge: FiniteDuration, minMultiConfAge: FiniteDuration, republishTimeout: FiniteDuration, limit: Int
+		initialDelay: FiniteDuration,
+    interval: FiniteDuration,
+    minMsgAge: FiniteDuration,
+    minMultiConfAge: FiniteDuration,
+    republishTimeout: FiniteDuration,
+		limit: Int
 	)(implicit ec: ExecutionContext): Unit = {
 		actorSystem.scheduler.schedule(initialDelay, interval)(resendUnconfirmed(minMsgAge, minMultiConfAge, republishTimeout, limit))
 	}
 
-	private def resendUnconfirmed(minMsgAge: FiniteDuration, minMultiConfAge: FiniteDuration, republishTimeout: FiniteDuration, limit: Int)(implicit ec: ExecutionContext): Unit = {
+	private def resendUnconfirmed(
+		minMsgAge: FiniteDuration,
+		minMultiConfAge: FiniteDuration,
+		republishTimeout: FiniteDuration,
+		limit: Int)(implicit ec: ExecutionContext): Unit = {
 		producers.foreach {
 			case (exchange, producer) =>
 				val current = System.currentTimeMillis()
@@ -83,7 +92,11 @@ class UnconfirmedMessageRepeater(
 	 * Resend the messages in the list and if managed to publish, delete msg and matching confirmation from the store
 	 */
 	private def resendAndDelete(
-		msgs: List[Message], confs: List[MessageConfirmation], producer: AmqpProducer, transactional: TransactionalMessageStore, republishTimeout: FiniteDuration
+		msgs: List[Message],
+		confs: List[MessageConfirmation],
+		producer: AmqpProducer,
+		transactional: TransactionalMessageStore,
+		republishTimeout: FiniteDuration
 	)(implicit ec: ExecutionContext): Unit = {
 		msgs.map { msg =>
 			val result = Try(Await.result(producer.publish(msg.routingKey, Json.parse(msg.message)), republishTimeout))
@@ -104,7 +117,10 @@ class UnconfirmedMessageRepeater(
 		}
 	}
 
-	private def deleteMessageAndMatchingConfirm(msg: Message, confs: List[MessageConfirmation], transactional: TransactionalMessageStore): Unit = {
+	private def deleteMessageAndMatchingConfirm(
+		msg: Message,
+		confs: List[MessageConfirmation],
+		transactional: TransactionalMessageStore): Unit = {
 		transactional.deleteMessage(
 			msg.id.getOrElse(throw new IllegalStateException(s"""Fetched message doesn't an have id: $msg"""))
 		)


### PR DESCRIPTION
### What does this PR do? How does it affect users?
- New version of the provider: MessageStore interface has deleteMultiConfIfNoMatchingMsg method for confirmation cleanup.
- other than that minor inner cleanup for parameters

@stratiator could you please check?

cc @privateblue 
