### PR TITLE
 Dead connection handling fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,15 @@ name := "amqp-client-provider"
 
 organization := "com.kinja"
 
-version := "0.5.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.5.1" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 scalaVersion := "2.10.3"
 
 scalacOptions  ++= Seq("-feature", "-language:postfixOps")
 
 shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project + "> " }
+
+incOptions := incOptions.value.withNameHashing(true)
 
 libraryDependencies ++= Seq(
     "com.kinja" %% "amqp-client" % "1.5.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ resolvers += "Gawker Public Group" at "https://nexus.kinja-ops.com/nexus/content
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 
-addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.4.0")

--- a/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
@@ -35,7 +35,14 @@ trait AmqpClientRegistry {
 		val conf = configuration.resendConfig.getOrElse(throw new MissingResendConfigException)
 		val repeater = new UnconfirmedMessageRepeater(actorSystem, messageStore, producers, logger)
 
-		repeater.startSchedule(conf.initialDelayInSec, conf.interval, conf.minMsgAge, conf.minMultiConfAge, conf.republishTimeoutInSec, conf.messageBatchSize)(ec)
+		repeater.startSchedule(
+			conf.initialDelayInSec,
+			conf.interval,
+			conf.minMsgAge,
+			conf.minMultiConfAge,
+			conf.republishTimeoutInSec,
+			conf.messageBatchSize
+		)(ec)
 	}
 
 	private def createProducers(): Map[String, AmqpProducer] = {

--- a/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
@@ -12,12 +12,13 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 case class ResendLoopConfig(
-		republishTimeoutInSec: FiniteDuration,
-		initialDelayInSec: FiniteDuration,
-		interval: FiniteDuration,
-		minMsgAge: FiniteDuration,
-		minMultiConfAge: FiniteDuration,
-		messageBatchSize: Int)
+	republishTimeoutInSec: FiniteDuration,
+	initialDelayInSec: FiniteDuration,
+	interval: FiniteDuration,
+	minMsgAge: FiniteDuration,
+	minMultiConfAge: FiniteDuration,
+	messageBatchSize: Int
+)
 
 trait AmqpConfiguration {
 	protected val config: Config
@@ -60,7 +61,6 @@ trait AmqpConfiguration {
 			name -> createExchangeParams(name)
 		}.toMap ++ getBuiltInExchangeParams
 	}
-
 
 	private def createQueueParamsForAll(): Map[String, QueueWithRelatedParameters] = {
 		val names: Set[String] = config.getConfig("messageQueue.queues").root().keySet().asScala.toSet

--- a/src/main/scala/com/kinja/amqp/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/MessageStore.scala
@@ -6,6 +6,7 @@ import com.kinja.amqp.model.MessageConfirmation
 trait MessageStore {
 
 	def saveConfirmation(conf: MessageConfirmation): Unit
+
 	def saveMessage(msg: Message): Unit
 
 	/**

--- a/src/main/scala/com/kinja/amqp/QueueWithRelatedParameters.scala
+++ b/src/main/scala/com/kinja/amqp/QueueWithRelatedParameters.scala
@@ -6,4 +6,5 @@ case class QueueWithRelatedParameters(
 	queueParams: QueueParameters,
 	boundExchange: ExchangeParameters,
 	deadLetterExchange: Option[ExchangeParameters],
-	bindingKey: String)
+	bindingKey: String
+)

--- a/src/main/scala/com/kinja/amqp/TransactionalMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/TransactionalMessageStore.scala
@@ -11,9 +11,9 @@ import com.kinja.amqp.model.MessageConfirmation
  */
 trait TransactionalMessageStore {
 
-	def start: Unit
+	def start(): Unit
 
-	def commit: Unit
+	def commit(): Unit
 
 	def loadMessageOlderThan(time: Long, exchangeName: String, limit: Int): List[Message]
 

--- a/src/main/scala/com/kinja/amqp/exception/Exception.scala
+++ b/src/main/scala/com/kinja/amqp/exception/Exception.scala
@@ -1,7 +1,11 @@
 package com.kinja.amqp.exception
 
-class MissingProducerException(name: String) extends Exception(s"""There is no producer for exchange with name "$name", please check your configuration.""")
+class MissingProducerException(name: String) extends Exception(
+	s"""There is no producer for exchange with name "$name", please check your configuration."""
+)
 
-class MissingConsumerException(name: String) extends Exception(s"""There is no consumer for queue with name "$name", please check your configuration.""")
+class MissingConsumerException(name: String) extends Exception(
+	s"""There is no consumer for queue with name "$name", please check your configuration."""
+)
 
 class MissingResendConfigException extends Exception("Resend loop configuration is missing")


### PR DESCRIPTION
- fix resending logic: don't duplicate messages in messagestore when trying to send to a dead connection
- fix for readding confirmation select confirmation listeners and exchange, queue and binding declarations on connection lost
- reformatted long lines
- updated scalariform
- set namehashing to match kinja repos, so it could be included as dependency from filesystem

@leventem can you please review?
