### PR TITLE
Add execution context to client registry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "amqp-client-provider"
 
 organization := "com.kinja"
 
-version := "0.8.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
+version := "0.9.0" + {if (System.getProperty("JENKINS_BUILD") == null) "-SNAPSHOT" else ""}
 
 scalaVersion := "2.10.3"
 

--- a/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
@@ -59,9 +59,8 @@ trait AmqpClientRegistry {
 					messageStore,
 					configuration.connectionTimeOut,
 					configuration.askTimeOut,
-					logger,
-					ec
-				)(params)
+					logger
+				)(params, ec)
 		}
 	}
 

--- a/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientRegistry.scala
@@ -20,6 +20,8 @@ trait AmqpClientRegistry {
 
 	protected val messageStore: MessageStore
 
+	protected val ec: ExecutionContext
+
 	val producers: Map[String, AmqpProducer] = createProducers()
 
 	val consumers: Map[String, AmqpConsumer] = createConsumers()
@@ -32,7 +34,7 @@ trait AmqpClientRegistry {
 		consumers.getOrElse(queueName, throw new MissingConsumerException(queueName))
 	}
 
-	def startMessageRepeater()(implicit ec: ExecutionContext) = {
+	def startMessageRepeater() = {
 		val conf = configuration.resendConfig.getOrElse(throw new MissingResendConfigException)
 		val repeater = new MessageBufferProcessor(actorSystem, messageStore, producers, logger)(
 			conf.initialDelayInSec,
@@ -57,7 +59,8 @@ trait AmqpClientRegistry {
 					messageStore,
 					configuration.connectionTimeOut,
 					configuration.askTimeOut,
-					logger
+					logger,
+					ec
 				)(params)
 		}
 	}

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -23,13 +23,11 @@ class AmqpProducer(
 	messageStore: MessageStore,
 	connectionTimeOut: Long,
 	askTimeout: Long,
-	logger: Slf4jLogger,
-	ec: ExecutionContext
-)(val exchange: ExchangeParameters) {
+	logger: Slf4jLogger
+)(val exchange: ExchangeParameters, implicit val ec: ExecutionContext) {
 
 	private implicit val timeout = Timeout(askTimeout.seconds)
 	private val channel: ActorRef = createChannel()
-	private implicit val eCtxt: ExecutionContext = ec
 
 	def publish[A: Writes](
 		routingKey: String, message: A, saveTimeMillis: Long = System.currentTimeMillis()

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -7,15 +7,15 @@ import akka.actor._
 import akka.pattern.ask
 import akka.util.Timeout
 import com.github.sstone.amqp.Amqp._
-import com.github.sstone.amqp.{Amqp, ChannelOwner, ConnectionOwner}
-import com.kinja.amqp.model.{Message, MessageConfirmation}
+import com.github.sstone.amqp.{ Amqp, ChannelOwner, ConnectionOwner }
+import com.kinja.amqp.model.{ Message, MessageConfirmation }
 import com.kinja.amqp.persistence.MessageStore
 import com.rabbitmq.client.AMQP.BasicProperties
-import org.slf4j.{Logger => Slf4jLogger}
+import org.slf4j.{ Logger => Slf4jLogger }
 import play.api.libs.json._
 
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 class AmqpProducer(
 	connection: ActorRef,
@@ -23,15 +23,17 @@ class AmqpProducer(
 	messageStore: MessageStore,
 	connectionTimeOut: Long,
 	askTimeout: Long,
-	logger: Slf4jLogger
+	logger: Slf4jLogger,
+	ec: ExecutionContext
 )(val exchange: ExchangeParameters) {
 
 	private implicit val timeout = Timeout(askTimeout.seconds)
 	private val channel: ActorRef = createChannel()
+	private implicit val eCtxt: ExecutionContext = ec
 
 	def publish[A: Writes](
 		routingKey: String, message: A, saveTimeMillis: Long = System.currentTimeMillis()
-	)(implicit ec: ExecutionContext): Future[Unit] = {
+	): Future[Unit] = {
 		val json = Json.toJson(message)
 		val bytes = json.toString.getBytes(java.nio.charset.Charset.forName("UTF-8"))
 		val properties = new BasicProperties.Builder().deliveryMode(2).build()
@@ -69,17 +71,15 @@ class AmqpProducer(
 
 	private def handleConfirm(
 		channelId: String, deliveryTag: Long, multiple: Boolean, timestamp: Long
-	)(implicit ec: ExecutionContext): Unit = {
+	): Unit = {
 		Future {
 			if (multiple) {
 				logger.debug("[RabbitMQ] Got multiple confirmation, saving...")
 				messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple, new Date(timestamp)))
-			}
-			else {
+			} else {
 				if (messageStore.deleteMessageUponConfirm(channelId, deliveryTag) > 0) {
 					logger.debug("[RabbitMQ] Message deleted upon confirm, no need to save confirmation")
-				}
-				else {
+				} else {
 					logger.debug("[RabbitMQ] Message wasn't deleted upon confirm, saving confirmation")
 					messageStore.saveConfirmation(MessageConfirmation(None, channelId, deliveryTag, multiple, new Date(timestamp)))
 				}
@@ -92,7 +92,7 @@ class AmqpProducer(
 	private def createConfirmListener: ActorRef = actorSystem.actorOf(Props(new Actor {
 		def receive = {
 			case HandleAck(deliveryTag, multiple, channelId, timestamp) =>
-				handleConfirm(channelId, deliveryTag, multiple, timestamp)(context.dispatcher)
+				handleConfirm(channelId, deliveryTag, multiple, timestamp)
 			case HandleNack(deliveryTag, multiple, channelId, timestamp) =>
 				logger.warn(
 					s"""[RabbitMQ] Receiving HandleNack with delivery tag: $deliveryTag,

--- a/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
+++ b/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
@@ -5,13 +5,13 @@ import java.util.concurrent.TimeoutException
 import akka.actor.ActorSystem
 import com.kinja.amqp.model.Message
 import com.kinja.amqp.persistence.MessageStore
-import org.slf4j.{Logger => Slf4jLogger}
+import org.slf4j.{ Logger => Slf4jLogger }
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{ Await, ExecutionContext }
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 /**
  * @param initialDelay The delay to start scheduling after

--- a/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
@@ -3,12 +3,12 @@ package com.kinja.amqp.persistence
 import java.sql.Date
 import java.text.SimpleDateFormat
 
-import com.kinja.amqp.model.{Message, MessageConfirmation}
+import com.kinja.amqp.model.{ Message, MessageConfirmation }
 
 import scala.slick.driver.ExtendedProfile
 import scala.slick.jdbc.GetResult.GetLong
-import scala.slick.jdbc.{GetResult, StaticQuery}
-import scala.slick.lifted.{BaseTypeMapper, ColumnBase}
+import scala.slick.jdbc.{ GetResult, StaticQuery }
+import scala.slick.lifted.{ BaseTypeMapper, ColumnBase }
 
 abstract class MySqlMessageStore(processId: String) extends MessageStore {
 

--- a/src/main/scala/com/kinja/amqp/persistence/NullMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/NullMessageStore.scala
@@ -1,6 +1,6 @@
 package com.kinja.amqp.persistence
 
-import com.kinja.amqp.model.{Message, MessageConfirmation}
+import com.kinja.amqp.model.{ Message, MessageConfirmation }
 
 object NullMessageStore extends MessageStore {
 


### PR DESCRIPTION
The user of the library will only have to pass in execution context when they put together the AmqpClientRegistry.

Bcz of scalariform formatting, the change turned to be a bit noisy.

@stratiator could you please check?
cc @privateblue 
