### PR TITLE
Rate limiting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import com.typesafe.sbt.SbtScalariform._
 
 name := "amqp-client-provider"
 
+version := "1.0.1-SNAPSHOT"
+
 organization := "com.kinja"
 
 scalaVersion := "2.10.4"
@@ -63,11 +65,3 @@ publishTo <<= (version)(version =>
 resolvers += "Public Group" at nexusUrl + nexusPublicGroupPath
 
 resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
-
-enablePlugins(GitVersioning)
-
-git.gitTagToVersionNumber := { tag: String =>
-    Some(tag.replace("release/", ""))
-}
-
-git.uncommittedSignifier := None

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.sbt.SbtScalariform._
 
 name := "amqp-client-provider"
 
-version := "1.0.1-SNAPSHOT"
+version := "1.0.1"
 
 organization := "com.kinja"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")

--- a/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
@@ -16,7 +16,7 @@ import play.api.libs.json._
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 class AmqpConsumer(
@@ -26,8 +26,17 @@ class AmqpConsumer(
 	logger: Slf4jLogger
 )(val params: QueueWithRelatedParameters) extends AmqpConsumerInterface {
 
-	def subscribe[A: Reads](processor: A => Unit): Unit = {
-		val listener = createListener(processor)
+	/**
+	 * @inheritdoc
+	 */
+	override def subscribe[A: Reads](processor: A => Unit): Unit =
+		subscribe(Duration.Zero, processor)
+
+	/**
+	 * @inheritdoc
+	 */
+	override def subscribe[A: Reads](spacing: FiniteDuration, processor: A => Unit): Unit = {
+		val listener = createListener(spacing, processor)
 
 		val initDeadLetterExchangeRequest = params.deadLetterExchange.map(
 			exchangeParams => Record(DeclareExchange(exchangeParams))
@@ -38,26 +47,52 @@ class AmqpConsumer(
 		)
 		val initRequests = List(initDeadLetterExchangeRequest, bindingRequest).flatten
 
+		// make sure to only consume one message at a time of rate limiting is enabled
+		val channelParams = if (spacing.toNanos > 0) Some(ChannelParameters(1)) else None
+
 		val consumer = ConnectionOwner.createChildActor(
 			connection,
-			Consumer.props(listener = Some(listener), init = initRequests, autoack = false),
+			Consumer.props(listener = Some(listener), channelParams = channelParams, init = initRequests, autoack = false),
 			Some("consumer_" + params.queueParams.name)
 		)
 
 		Amqp.waitForConnection(actorSystem, connection, consumer).await(connectionTimeOut.toSeconds, TimeUnit.SECONDS)
 	}
 
-	private def createListener[A: Reads](processor: A => Unit): ActorRef = {
+	private case object WakeUp
+
+	private def createListener[A: Reads](spacing: FiniteDuration, processor: A => Unit): ActorRef = {
 		actorSystem.actorOf(Props(new Actor {
+
+			/**
+			 * Processing of next message may start immediately if the time until next tick is less
+			 * than this number.
+			 */
+			private val toleranceNanos = 10000000L // 10 milliseconds
+
+			/**
+			 * Default state of the listener which receives messages from RabbitMQ.
+			 */
 			def receive = {
 				case Delivery(consumerTag, envelope, properties, body) =>
+					val nextTickNanos = System.nanoTime + spacing.toNanos
 					val s = new String(body, "UTF-8")
 					try {
 						val json = Json.parse(s)
 						try {
 							val message = json.as[A]
 							processor(message)
-							sender ! Ack(envelope.getDeliveryTag)
+							val ack = Ack(envelope.getDeliveryTag)
+
+							// sleep until we are allowd to receive a new message
+							val nowNanos = System.nanoTime
+							if (nowNanos < nextTickNanos - toleranceNanos) {
+								implicit val ec = context.dispatcher
+								context.system.scheduler.scheduleOnce((nextTickNanos - nowNanos).nanos, self, WakeUp)
+								context.become(asleep(sender, ack))
+							} else {
+								sender ! ack
+							}
 						} catch {
 							case e: JsResultException =>
 								logger.warn(s"""[RabbitMQ] Couldn't parse json "$json" : $e""")
@@ -71,6 +106,14 @@ class AmqpConsumer(
 							logger.warn(s"""[RabbitMQ] Couldn't parse string "$s" as json: $t""")
 							sender ! Reject(envelope.getDeliveryTag, requeue = false)
 					}
+			}
+
+			def asleep(originalSender: ActorRef, ack: Ack): Receive = {
+				case WakeUp =>
+					originalSender ! ack
+					context.unbecome()
+				case Delivery(_, envelope, _, _) =>
+					sender ! Reject(envelope.getDeliveryTag, requeue = true)
 			}
 		}))
 	}

--- a/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
@@ -1,7 +1,27 @@
 package com.kinja.amqp
 
 import play.api.libs.json.Reads
+import scala.concurrent.duration.FiniteDuration
 
 trait AmqpConsumerInterface {
+
+	/**
+	 * Subscribes the message processor function to consume the queue described by params.
+	 * @param processor The pmessage processor function.
+	 */
 	def subscribe[A: Reads](processor: A => Unit): Unit
+
+	/**
+	 * Subscribes the message processor function to consume the queue described by params.
+	 * @param spacing The minimum amount of time that has to elapse between starting processing
+	 *        new messages. It can be used to define rate limiting, for example, setting 10
+	 *        seconds here means that only one message may be processed each 10 seconds, resulting
+	 *        in a processing rate of 0.1 message/sec. Note that this is not the time to wait
+	 *        between processing messages (end of last and beginning of next) but rather
+	 *        the time between the start of each processing. This means, sticking to the previous
+	 *        example, that if processing took more than 10 seconds, processing the next message
+	 *        can immediately be started.
+	 * @param processor The pmessage processor function.
+	 */
+	def subscribe[A: Reads](spacing: FiniteDuration, processor: A => Unit): Unit
 }

--- a/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
@@ -1,7 +1,9 @@
 package com.kinja.amqp
 
 import play.api.libs.json.Reads
+import scala.concurrent.duration.FiniteDuration
 
 class NullAmqpConsumer extends AmqpConsumerInterface {
-	override def subscribe[A: Reads](processor: (A) => Unit): Unit = {}
+	override def subscribe[A: Reads](processor: (A) => Unit): Unit = ()
+	override def subscribe[A: Reads](spacing: FiniteDuration, processor: (A) => Unit): Unit = ()
 }


### PR DESCRIPTION
### What does this PR do? How does it affect users?

This PR adds the ability to rate-limit processing the messages of a queue. Rate-limiting can be enabled by defining the spacing (minimum time interval) between the start times of processing messages.
### How should this be tested (feature switches, URLs, special user permissions)?

Create a subscription with spacing greater than zero, push a few messages into the related queue and watch the RabbitMQ management interface to see at what rate they're consumed.
### Related Trello card, wiki page or blog posts

N/A
