### PR TITLE
No Play

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ package com.kinja.presentation.controller
 import com.kinja.common.logging.Logging
 import com.kinja.presentation.dependencies._
 
-import play.api.libs.json.Json
 import play.api.mvc._
 
 import scala.concurrent.Future

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,26 @@ SbtScalariform.scalariformSettings ++ Seq(
         .setPreference(DoubleIndentClassDeclaration, false)
 )
 
+// Scala linting to help preventing bugs
+wartremoverErrors ++= Seq(
+    Wart.IsInstanceOf,   // Prevent type-casing.
+    // Wart.AsInstanceOf,   // Prevent dynamic types.
+    Wart.Return,         // Prevent use of `return` keyword.
+    Wart.Any2StringAdd,  // Prevent accidental stringification.
+    Wart.OptionPartial,  // Option.get is unsafe.
+    Wart.TryPartial,     // Try.get is unsafe.
+    Wart.ListOps,        // Prevent throwing exceptions in List's functions.
+    Wart.Null,           // Prevent using null.
+    Wart.Product,        // Prevent incorrect generic types.
+    Wart.Serializable,   // Prevent incorrect generic types.
+    Wart.Var,            // Prevent using var.
+    Wart.Enumeration,    // Prevent using Scala enumerations.
+    Wart.ToString,       // Prevent automatic string conversion.
+    Wart.FinalCaseClass, // Case classes should always be final.
+    Wart.ExplicitImplicitTypes,  // Force explicit type annotations for implicits.
+    Wart.EitherProjectionPartial // Prevent throwing exceptions.
+)
+
 def getEnvOrDefault(key: String, default: String): String = {
     if (System.getenv().containsKey(key)) {
         System.getenv(key)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "2.0.0-SNAPSHOT"
+version := "2.0.0"
 
 organization := "com.kinja"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,41 +1,61 @@
-import com.typesafe.sbt.SbtScalariform._
+import scalariform.formatter.preferences._
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "1.0.1"
+version := "1.1.0-SNAPSHOT"
 
 organization := "com.kinja"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.6"
 
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 
-scalacOptions  ++= Seq("-feature", "-language:postfixOps")
+scalacOptions ++= Seq(
+    "-unchecked",            // Show details of unchecked warnings.
+    "-deprecation",          // Show details of deprecation warnings.
+    "-feature",              // Show details of feature warnings.
+    "-Xfatal-warnings",      // All warnings should result in a compiliation failure.
+    "-Ywarn-dead-code",      // Fail when dead code is present. Prevents accidentally unreachable code.
+    "-encoding", "UTF-8",    // Set correct encoding for Scaladoc.
+    "-Xfuture",              // Disables view bounds, adapted args, and unsound pattern matching in 2.11.
+    "-Yno-adapted-args",     // Prevent implicit tupling of arguments.
+    "-Ywarn-value-discard",  // Prevent accidental discarding of results in unit functions.
+    "-Xmax-classfile-name", "140"
+)
 
-shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project + "> " }
+javacOptions ++= Seq(
+    "-Xlint:deprecation"
+)
 
 incOptions := incOptions.value.withNameHashing(true)
+
+updateOptions := updateOptions.value.withCachedResolution(true)
+
+shellPrompt in ThisBuild := { state => Project.extract(state).currentRef.project + "> " }
 
 val akkaVersion = "2.3.12"
 
 libraryDependencies ++= Seq(
     "com.kinja" %% "amqp-client" % "1.5.1",
-    "com.typesafe.play" %% "play-json" % "2.3.4",
-    "com.typesafe.akka" %% "akka-actor" % akkaVersion % "provided",
-    "ch.qos.logback" % "logback-classic" % "1.0.0" % "provided",
+    "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
+    "ch.qos.logback" % "logback-classic" % "1.0.0" % Provided,
     // Test dependencies
-    "org.specs2" %% "specs2-core" % "3.6" % "test",
-    "org.specs2" %% "specs2-junit" % "3.6" % "test",
-    "org.specs2" %% "specs2-mock" % "3.6" % "test",
-    "org.specs2" %% "specs2-scalacheck" % "3.6" % "test",
-    "com.h2database" % "h2" % "1.4.187" % "test"
+    "org.specs2" %% "specs2-core" % "3.6" % Test,
+    "org.specs2" %% "specs2-junit" % "3.6" % Test,
+    "org.specs2" %% "specs2-mock" % "3.6" % Test,
+    "org.specs2" %% "specs2-scalacheck" % "3.6" % Test,
+    "com.h2database" % "h2" % "1.4.187" % Test
 )
 
 // code formatting
-ScalariformKeys.preferences := scalariform.formatter.preferences.FormattingPreferences()
-    .setPreference(scalariform.formatter.preferences.IndentWithTabs, true)
-    .setPreference(scalariform.formatter.preferences.SpacesAroundMultiImports, true)
-    .setPreference(scalariform.formatter.preferences.PreserveDanglingCloseParenthesis, true)
+SbtScalariform.scalariformSettings ++ Seq(
+    ScalariformKeys.preferences := ScalariformKeys.preferences.value
+        .setPreference(IndentWithTabs, true)
+        .setPreference(DanglingCloseParenthesis, Preserve)
+        .setPreference(DoubleIndentClassDeclaration, false)
+)
 
 def getEnvOrDefault(key: String, default: String): String = {
     if (System.getenv().containsKey(key)) {

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "1.1.0-SNAPSHOT"
+version := "2.0.0-SNAPSHOT"
 
 organization := "com.kinja"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,8 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.0")
+// Automatic code formatting
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+
+// Scalastyle
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+
+// Scala linting plugin
+addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")

--- a/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
 
-case class ResendLoopConfig(
+final case class ResendLoopConfig(
 	republishTimeoutInSec: FiniteDuration,
 	initialDelayInSec: FiniteDuration,
 	bufferProcessInterval: FiniteDuration,

--- a/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
@@ -54,7 +54,7 @@ class AmqpConsumer(
 			Some("consumer_" + params.queueParams.name)
 		)
 
-		Amqp.waitForConnection(actorSystem, connection, consumer).await(connectionTimeOut.toSeconds, TimeUnit.SECONDS)
+		ignore(Amqp.waitForConnection(actorSystem, connection, consumer).await(connectionTimeOut.toSeconds, TimeUnit.SECONDS))
 	}
 
 	private case object WakeUp

--- a/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
@@ -14,6 +14,7 @@ import org.slf4j.{ Logger => Slf4jLogger }
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
@@ -85,7 +86,7 @@ class AmqpConsumer(
 								// sleep until we are allowd to receive a new message
 								val nowNanos = System.nanoTime
 								if (nowNanos < nextTickNanos - toleranceNanos) {
-									implicit val ec = context.dispatcher
+									implicit val ec: ExecutionContext = context.dispatcher
 									context.system.scheduler.scheduleOnce((nextTickNanos - nowNanos).nanos, self, WakeUp)
 									context.become(asleep(sender, ack))
 								} else {

--- a/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
@@ -1,6 +1,5 @@
 package com.kinja.amqp
 
-import play.api.libs.json.Reads
 import scala.concurrent.duration.FiniteDuration
 
 trait AmqpConsumerInterface {

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -96,7 +96,7 @@ class AmqpProducer(
 	private def handleConfirmation(
 		channelId: String, deliveryTag: Long, multiple: Boolean, timestamp: Long
 	): Unit = {
-		Future {
+		ignore(Future {
 			if (multiple) {
 				logger.debug("[RabbitMQ] Got multiple confirmation, saving...")
 				messageStore.saveConfirmation(
@@ -113,7 +113,7 @@ class AmqpProducer(
 						)
 				}
 			}
-		}
+		})
 	}
 
 	private def createConfirmListener: ActorRef = actorSystem.actorOf(Props(new Actor {

--- a/src/main/scala/com/kinja/amqp/AmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducer.scala
@@ -25,7 +25,7 @@ class AmqpProducer(
 	logger: Slf4jLogger
 )(val exchange: ExchangeParameters, implicit val ec: ExecutionContext) extends AmqpProducerInterface {
 
-	private implicit val timeout = Timeout(askTimeout)
+	private implicit val timeout: Timeout = Timeout(askTimeout)
 	private val channel: ActorRef = createChannel()
 
 	def publish[A: Writes](

--- a/src/main/scala/com/kinja/amqp/AmqpProducerInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducerInterface.scala
@@ -1,6 +1,5 @@
 package com.kinja.amqp
 
-import play.api.libs.json.Writes
 import scala.concurrent.Future
 
 trait AmqpProducerInterface {

--- a/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
+++ b/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
@@ -2,7 +2,7 @@ package com.kinja.amqp
 
 import java.util.concurrent.TimeoutException
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, Cancellable }
 import com.kinja.amqp.model.Message
 import com.kinja.amqp.persistence.MessageStore
 import org.slf4j.{ Logger => Slf4jLogger }
@@ -37,14 +37,17 @@ class MessageBufferProcessor(
 	messageLockTimeOutAfter: FiniteDuration
 ) {
 
+	@SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Var"))
+	private var resendSchedule: Option[Cancellable] = None
+
 	/**
 	 * Schedules message resend logic periodically
 	 * @param ec Execution context used for scheduling and resend logic
 	 */
 	def startSchedule(implicit ec: ExecutionContext): Unit = ignore {
-		actorSystem.scheduler.schedule(initialDelay, bufferProcessInterval)(
+		resendSchedule = Some(actorSystem.scheduler.schedule(initialDelay, bufferProcessInterval)(
 			processMessageBuffer()
-		)
+		))
 	}
 
 	private def processMessageBuffer()(implicit ec: ExecutionContext): Unit = {
@@ -122,5 +125,9 @@ class MessageBufferProcessor(
 					logger.warn(s"""[RabbitMQ] Couldn't resend message: $msg, ${ex.getMessage}""")
 			}
 		}
+	}
+
+	def shutdown(): Unit = {
+		resendSchedule.foreach(_.cancel())
 	}
 }

--- a/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
+++ b/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
@@ -6,7 +6,6 @@ import akka.actor.ActorSystem
 import com.kinja.amqp.model.Message
 import com.kinja.amqp.persistence.MessageStore
 import org.slf4j.{ Logger => Slf4jLogger }
-import play.api.libs.json.Json
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext }
@@ -107,7 +106,7 @@ class MessageBufferProcessor(
 		republishTimeout: FiniteDuration
 	)(implicit ec: ExecutionContext): Unit = {
 		msgs.foreach { msg =>
-			val result = Try(Await.result(producer.publish(msg.routingKey, Json.parse(msg.message)), republishTimeout))
+			val result = Try(Await.result(producer.publish(msg.routingKey, msg.message), republishTimeout))
 			result match {
 				case Success(_) =>
 					messageStore.deleteMessage(

--- a/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
+++ b/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
@@ -41,7 +41,7 @@ class MessageBufferProcessor(
 	 * Schedules message resend logic periodically
 	 * @param ec Execution context used for scheduling and resend logic
 	 */
-	def startSchedule(implicit ec: ExecutionContext): Unit = {
+	def startSchedule(implicit ec: ExecutionContext): Unit = ignore {
 		actorSystem.scheduler.schedule(initialDelay, bufferProcessInterval)(
 			processMessageBuffer()
 		)

--- a/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
@@ -1,6 +1,5 @@
 package com.kinja.amqp
 
-import play.api.libs.json.Reads
 import scala.concurrent.duration.FiniteDuration
 
 class NullAmqpConsumer extends AmqpConsumerInterface {

--- a/src/main/scala/com/kinja/amqp/NullAmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpProducer.scala
@@ -7,5 +7,5 @@ class NullAmqpProducer extends AmqpProducerInterface {
 		routingKey: String,
 		message: A,
 		saveTimeMillis: Long = System.currentTimeMillis()
-	): Future[Unit] = Future.successful(Unit)
+	): Future[Unit] = Future.successful(())
 }

--- a/src/main/scala/com/kinja/amqp/NullAmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpProducer.scala
@@ -1,6 +1,5 @@
 package com.kinja.amqp
 
-import play.api.libs.json.Writes
 import scala.concurrent.Future
 
 class NullAmqpProducer extends AmqpProducerInterface {

--- a/src/main/scala/com/kinja/amqp/QueueWithRelatedParameters.scala
+++ b/src/main/scala/com/kinja/amqp/QueueWithRelatedParameters.scala
@@ -2,7 +2,7 @@ package com.kinja.amqp
 
 import com.github.sstone.amqp.Amqp._
 
-case class QueueWithRelatedParameters(
+final case class QueueWithRelatedParameters(
 	queueParams: QueueParameters,
 	boundExchange: ExchangeParameters,
 	deadLetterExchange: Option[ExchangeParameters],

--- a/src/main/scala/com/kinja/amqp/model/Message.scala
+++ b/src/main/scala/com/kinja/amqp/model/Message.scala
@@ -2,7 +2,7 @@ package com.kinja.amqp.model
 
 import java.sql.Timestamp
 
-case class Message(
+final case class Message(
 	id: Option[Long],
 	routingKey: String,
 	exchangeName: String,

--- a/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
+++ b/src/main/scala/com/kinja/amqp/model/MessageConfirmation.scala
@@ -2,7 +2,7 @@ package com.kinja.amqp.model
 
 import java.sql.Timestamp
 
-case class MessageConfirmation(
+final case class MessageConfirmation(
 	id: Option[Long],
 	channelId: String,
 	deliveryTag: Long,

--- a/src/main/scala/com/kinja/amqp/package.scala
+++ b/src/main/scala/com/kinja/amqp/package.scala
@@ -1,0 +1,22 @@
+package com.kinja
+
+package object amqp {
+
+	class ParsingException(msg: String) extends Exception(msg)
+
+	trait Reads[T] {
+		def reads(s: String): Either[ParsingException, T]
+	}
+
+	trait Writes[T] {
+		def writes(t: T): String
+	}
+
+	implicit val readsString: Reads[String] = new Reads[String] {
+		override def reads(s: String): Either[ParsingException, String] = Right(s)
+	}
+
+	implicit val writesString: Writes[String] = new Writes[String] {
+		override def writes(s: String): String = s
+	}
+}

--- a/src/main/scala/com/kinja/amqp/package.scala
+++ b/src/main/scala/com/kinja/amqp/package.scala
@@ -19,4 +19,10 @@ package object amqp {
 	implicit val writesString: Writes[String] = new Writes[String] {
 		override def writes(s: String): String = s
 	}
+
+	/**
+	 * Ignores the return value of a function. This can be used to work around the
+	 * "discarded non-Unit value" compile errors which aims to prevent bugs.
+	 */
+	private[amqp] def ignore[A](a: A): Unit = ()
 }

--- a/src/main/scala/com/kinja/amqp/package.scala
+++ b/src/main/scala/com/kinja/amqp/package.scala
@@ -4,18 +4,46 @@ package object amqp {
 
 	class ParsingException(msg: String) extends Exception(msg)
 
+	/**
+	 * Defines how to read a message of type `T` from its serialized string representation.
+	 *
+	 * @tparam T The type of the message.
+	 */
 	trait Reads[T] {
+
+		/**
+		 * Defines how to read a message from its serialized string representation.
+		 *
+		 * @param s The serialized message.
+		 * @return Either the deserialized value of `T` or a `ParsingException` if deserialization failed.
+		 */
 		def reads(s: String): Either[ParsingException, T]
 	}
 
+	/**
+	 * Defines how to write a message of type `T` into its serialized string representation.
+	 */
 	trait Writes[T] {
+
+		/**
+		 * Defines how to write a message of type `T` into its serialized string representation.
+		 *
+		 * @param t The message.
+		 * @return The serialized representation of the message.
+		 */
 		def writes(t: T): String
 	}
 
+	/**
+	 * The default deserializer for string messages.
+	 */
 	implicit val readsString: Reads[String] = new Reads[String] {
 		override def reads(s: String): Either[ParsingException, String] = Right(s)
 	}
 
+	/**
+	 * The default serializer for string messages.
+	 */
 	implicit val writesString: Writes[String] = new Writes[String] {
 		override def writes(s: String): String = s
 	}

--- a/src/main/scala/com/kinja/amqp/package.scala
+++ b/src/main/scala/com/kinja/amqp/package.scala
@@ -2,7 +2,12 @@ package com.kinja
 
 package object amqp {
 
-	class ParsingException(msg: String) extends Exception(msg)
+	/**
+	 * The exception that should be returned when deserializing a message failed.
+	 *
+	 * @param msg The deserialization error.
+	 */
+	class DeserializationException(msg: String) extends Exception(msg)
 
 	/**
 	 * Defines how to read a message of type `T` from its serialized string representation.
@@ -15,9 +20,9 @@ package object amqp {
 		 * Defines how to read a message from its serialized string representation.
 		 *
 		 * @param s The serialized message.
-		 * @return Either the deserialized value of `T` or a `ParsingException` if deserialization failed.
+		 * @return Either the deserialized value of `T` or a `DeserializationException` if deserialization failed.
 		 */
-		def reads(s: String): Either[ParsingException, T]
+		def reads(s: String): Either[DeserializationException, T]
 	}
 
 	/**
@@ -38,7 +43,7 @@ package object amqp {
 	 * The default deserializer for string messages.
 	 */
 	implicit val readsString: Reads[String] = new Reads[String] {
-		override def reads(s: String): Either[ParsingException, String] = Right(s)
+		override def reads(s: String): Either[DeserializationException, String] = Right(s)
 	}
 
 	/**

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBuffer.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBuffer.scala
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 
 import akka.actor.{ Actor, ActorLogging }
 import akka.event.LoggingReceive
+import com.kinja.amqp.ignore
 import com.kinja.amqp.model.{ Message, MessageConfirmation }
 import org.slf4j.{ Logger => Slf4jLogger }
 
@@ -38,7 +39,7 @@ class InMemoryMessageBuffer extends Actor with ActorLogging {
 		confirmations.update(confirm.channelId, confirm.deliveryTag)
 	}
 
-	private def saveMessage(message: Message): Unit = messageBuffer += message
+	private def saveMessage(message: Message): Unit = ignore(messageBuffer += message)
 
 	private def deleteMessageUponConfirm(channelId: String, deliveryTag: Long): Unit = {
 		val messageToDelete: Option[Message] = messageBuffer.find(message =>

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBuffer.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBuffer.scala
@@ -10,13 +10,13 @@ import org.slf4j.{ Logger => Slf4jLogger }
 
 import scala.collection.mutable.{ ArrayBuffer, Map => MutableMap }
 
-case class SaveMessage(message: Message)
-case class MultipleConfirmation(confirm: MessageConfirmation)
-case class DeleteMessageUponConfirm(channelId: String, deliveryTag: Long)
-case class RemoveMessagesOlderThan(milliSeconds: Long)
+final case class SaveMessage(message: Message)
+final case class MultipleConfirmation(confirm: MessageConfirmation)
+final case class DeleteMessageUponConfirm(channelId: String, deliveryTag: Long)
+final case class RemoveMessagesOlderThan(milliSeconds: Long)
 case object GetAllMessages
 case object RemoveMultipleConfirmations
-case class LogBufferStatistics(logger: Slf4jLogger)
+final case class LogBufferStatistics(logger: Slf4jLogger)
 
 class InMemoryMessageBuffer extends Actor with ActorLogging {
 

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
@@ -21,7 +21,7 @@ class InMemoryMessageBufferDecorator(
 	askTimeout: FiniteDuration
 )(implicit val ec: ExecutionContext) extends MessageStore {
 
-	private implicit val timeout = Timeout(askTimeout)
+	private implicit val timeout: Timeout = Timeout(askTimeout)
 
 	private val inMemoryMessageBuffer: ActorRef = actorSystem.actorOf(Props(new InMemoryMessageBuffer))
 

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
@@ -3,6 +3,7 @@ package com.kinja.amqp.persistence
 import akka.actor.{ Cancellable, ActorRef, ActorSystem, Props }
 import akka.pattern.ask
 import akka.util.Timeout
+import com.kinja.amqp.ignore
 import com.kinja.amqp.model.{ Message, MessageConfirmation }
 import org.slf4j.{ Logger => Slf4jLogger }
 
@@ -27,7 +28,7 @@ class InMemoryMessageBufferDecorator(
 	logger.debug("Scheduling memory flusher...")
 
 	private val memoryFlushSchedule: Cancellable = actorSystem.scheduler.schedule(
-		1 second, memoryFlushInterval
+		1.second, memoryFlushInterval
 	)(flushMemoryBufferToMessageStore())
 
 	logger.debug("Memory flusher scheduled")
@@ -106,7 +107,7 @@ class InMemoryMessageBufferDecorator(
 			f
 		} catch {
 			case NonFatal(t) => logger.error(
-				s"[RabbitMQ] Exception while trying to flush in-memory buffer: $t,\n Trace:${t.getStackTraceString}"
+				s"[RabbitMQ] Exception while trying to flush in-memory buffer: $t,\n Trace:${t.getStackTrace}"
 			)
 		}
 	}
@@ -160,7 +161,7 @@ class InMemoryMessageBufferDecorator(
 				inMemoryMessageBuffer ? RemoveMultipleConfirmations
 			)
 
-			memoryFlushSchedule.cancel()
+			ignore(memoryFlushSchedule.cancel())
 		}
 	}
 }

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
@@ -149,6 +149,8 @@ class InMemoryMessageBufferDecorator(
 		tryWithLogging {
 			logger.info("Shutdown: flushing memory buffer to message store...")
 
+			ignore(memoryFlushSchedule.cancel())
+
 			if (logger.isInfoEnabled) {
 				inMemoryMessageBuffer ? LogBufferStatistics(logger)
 			}
@@ -160,8 +162,6 @@ class InMemoryMessageBufferDecorator(
 			handleConfirmationsResponseFromBuffer(
 				inMemoryMessageBuffer ? RemoveMultipleConfirmations
 			)
-
-			ignore(memoryFlushSchedule.cancel())
 		}
 	}
 }

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
@@ -107,7 +107,7 @@ class InMemoryMessageBufferDecorator(
 			f
 		} catch {
 			case NonFatal(t) => logger.error(
-				s"[RabbitMQ] Exception while trying to flush in-memory buffer: $t,\n Trace:${t.getStackTrace}"
+				s"[RabbitMQ] Exception while trying to flush in-memory buffer: ${t.getMessage}", t
 			)
 		}
 	}

--- a/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
@@ -45,7 +45,7 @@ class MySqlMessageStore(
 			id ~ channelId ~ deliveryTag ~ multiple ~ createdTime
 	}
 
-	implicit val getMessage = GetResult(r => Message(
+	implicit val getMessage: GetResult[Message] = GetResult(r => Message(
 		id = r.read[Option[Long]]("id"),
 		routingKey = r.read[String]("routingKey"),
 		exchangeName = r.read[String]("exchangeName"),
@@ -57,7 +57,7 @@ class MySqlMessageStore(
 		lockedAt = r.read[Option[Timestamp]]("lockedAt")
 	))
 
-	implicit val getConfirmation = GetResult(r => MessageConfirmation(
+	implicit val getConfirmation: GetResult[MessageConfirmation] = GetResult(r => MessageConfirmation(
 		id = r.read[Option[Long]]("id"),
 		channelId = r.read[String]("channelId"),
 		deliveryTag = r.read[Long]("deliveryTag"),
@@ -65,7 +65,7 @@ class MySqlMessageStore(
 		createdTime = r.read[Timestamp]("createdTime")
 	))
 
-	implicit val setMessageAutoInc = SetResult[Message] { (stmt, message) =>
+	implicit val setMessageAutoInc: SetResult[Message] = SetResult[Message] { (stmt, message) =>
 		stmt.setNull(1, Types.BIGINT) // NULL for autoinc
 		stmt.setString(2, message.routingKey)
 		stmt.setString(3, message.exchangeName)
@@ -77,7 +77,7 @@ class MySqlMessageStore(
 		message.lockedAt.map(v => stmt.setTimestamp(9, v)).getOrElse(stmt.setNull(9, Types.TIMESTAMP))
 	}
 
-	implicit val setConfirmationAutoInc = SetResult[MessageConfirmation] { (stmt, confirm) =>
+	implicit val setConfirmationAutoInc: SetResult[MessageConfirmation] = SetResult[MessageConfirmation] { (stmt, confirm) =>
 		stmt.setNull(1, Types.BIGINT) // NULL for autoinc
 		stmt.setString(2, confirm.channelId)
 		stmt.setLong(3, confirm.deliveryTag)

--- a/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
@@ -3,6 +3,7 @@ package com.kinja.amqp.persistence
 import java.sql.{ Date, Timestamp }
 import java.text.SimpleDateFormat
 
+import com.kinja.amqp.ignore
 import com.kinja.amqp.model.{ Message, MessageConfirmation }
 
 import scala.concurrent.Future
@@ -179,17 +180,17 @@ class MySqlMessageStore(
 			"""
 	}
 
-	override def saveMessage(msg: Message): Unit = onWrite { implicit conn =>
+	override def saveMessage(msg: Message): Unit = ignore(onWrite { implicit conn =>
 		prepare(MessageTable.insertStatement) { stmt =>
 			stmt.insert(msg)
 		}
-	}
+	})
 
-	override def saveConfirmation(confirm: MessageConfirmation): Unit = onWrite { implicit conn =>
+	override def saveConfirmation(confirm: MessageConfirmation): Unit = ignore(onWrite { implicit conn =>
 		prepare(MessageConfirmationTable.insertStatement) { stmt =>
 			stmt.insert(confirm)
 		}
-	}
+	})
 
 	override def deleteMessageUponConfirm(channelId: String, deliveryTag: Long): Future[Boolean] = onWrite { implicit conn =>
 		prepare(Queries.deleteMessageByChannelAndDelivery) { stmt =>
@@ -214,12 +215,12 @@ class MySqlMessageStore(
 		}
 	}
 
-	override def deleteMessage(id: Long): Unit = onWrite { implicit conn =>
+	override def deleteMessage(id: Long): Unit = ignore(onWrite { implicit conn =>
 		prepare(Queries.deleteMessageById) { stmt =>
 			stmt.setLong(1, id)
 			stmt.executeUpdate
 		}
-	}
+	})
 
 	override def deleteMatchingMessagesAndSingleConfirms(): Int = onWrite { implicit conn =>
 		prepare(Queries.deleteMatchingMessagesAndSingleConfirms) { stmt =>

--- a/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/MySqlMessageStore.scala
@@ -13,8 +13,8 @@ import java.sql.{ Connection, PreparedStatement, ResultSet, Types }
 
 class MySqlMessageStore(
 	processId: String,
-	override val writeDs: javax.sql.DataSource,
-	override val readDs: javax.sql.DataSource
+	override val getWriteConnection: () => Connection,
+	override val getReadConnection: () => Connection
 ) extends MessageStore with ORM {
 
 	private val df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")

--- a/src/main/scala/com/kinja/amqp/persistence/ORM.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/ORM.scala
@@ -69,27 +69,27 @@ trait ORM {
 
 	private[persistence] trait Reads[T] extends Function2[ResultSet, String, T]
 
-	private[persistence] implicit val stringReads = new Reads[String] {
+	private[persistence] implicit val stringReads: Reads[String] = new Reads[String] {
 		def apply(r: ResultSet, column: String): String = r.getString(column)
 	}
 
-	private[persistence] implicit val longReads = new Reads[Long] {
+	private[persistence] implicit val longReads: Reads[Long] = new Reads[Long] {
 		def apply(r: ResultSet, column: String): Long = r.getLong(column)
 	}
 
-	private[persistence] implicit val intReads = new Reads[Int] {
+	private[persistence] implicit val intReads: Reads[Int] = new Reads[Int] {
 		def apply(r: ResultSet, column: String): Int = r.getInt(column)
 	}
 
-	private[persistence] implicit val booleanReads = new Reads[Boolean] {
+	private[persistence] implicit val booleanReads: Reads[Boolean] = new Reads[Boolean] {
 		def apply(r: ResultSet, column: String): Boolean = r.getBoolean(column)
 	}
 
-	private[persistence] implicit val timestampReads = new Reads[Timestamp] {
+	private[persistence] implicit val timestampReads: Reads[Timestamp] = new Reads[Timestamp] {
 		def apply(r: ResultSet, column: String): Timestamp = r.getTimestamp(column)
 	}
 
-	private[persistence] implicit def optionReads[T: Reads] = new Reads[Option[T]] {
+	private[persistence] implicit def optionReads[T: Reads]: Reads[Option[T]] = new Reads[Option[T]] {
 		def apply(r: ResultSet, column: String): Option[T] = {
 			val value = implicitly[Reads[T]].apply(r, column)
 			if (r.wasNull) None else Option(value)

--- a/src/main/scala/com/kinja/amqp/persistence/ORM.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/ORM.scala
@@ -45,7 +45,7 @@ trait ORM {
 		try {
 			block(conn)
 		} finally {
-			if (conn != null) conn.close()
+			if (Option(conn).isDefined) conn.close()
 		}
 	}
 
@@ -54,7 +54,7 @@ trait ORM {
 		try {
 			block(conn)
 		} finally {
-			if (conn != null) conn.close()
+			if (Option(conn).isDefined) conn.close()
 		}
 	}
 
@@ -63,7 +63,7 @@ trait ORM {
 		try {
 			block(stmt)
 		} finally {
-			if (stmt != null) stmt.close()
+			if (Option(stmt).isDefined) stmt.close()
 		}
 	}
 
@@ -134,6 +134,7 @@ trait ORM {
 			stmt.executeUpdate
 		}
 
+		@SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Var"))
 		def insertAll[T: SetResult](ts: Traversable[T])(implicit conn: Connection): Unit = {
 			val setResult = implicitly[SetResult[T]]
 			val autoCommit = conn.getAutoCommit()

--- a/src/main/scala/com/kinja/amqp/persistence/ORM.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/ORM.scala
@@ -15,8 +15,8 @@ import java.sql.{ Connection, PreparedStatement, ResultSet }
  */
 trait ORM {
 
-	val readDs: javax.sql.DataSource
-	val writeDs: javax.sql.DataSource
+	val getReadConnection: () => Connection
+	val getWriteConnection: () => Connection
 
 	private[persistence] class ColumnBase(val columns: List[Column]) {
 		def ~(other: Column): ColumnBase = new ColumnBase(columns :+ other)
@@ -41,7 +41,7 @@ trait ORM {
 	}
 
 	private[persistence] def onRead[T](block: Connection => T): T = {
-		val conn = readDs.getConnection()
+		val conn = getReadConnection()
 		try {
 			block(conn)
 		} finally {
@@ -50,7 +50,7 @@ trait ORM {
 	}
 
 	private[persistence] def onWrite[T](block: Connection => T): T = {
-		val conn = writeDs.getConnection()
+		val conn = getWriteConnection()
 		try {
 			block(conn)
 		} finally {

--- a/src/test/scala/com/kinja/amqp/persistence/H2Database.scala
+++ b/src/test/scala/com/kinja/amqp/persistence/H2Database.scala
@@ -1,5 +1,6 @@
 package com.kinja.amqp.persistence
 
+import java.sql.Connection
 import javax.sql.DataSource
 import org.h2.jdbcx.JdbcDataSource
 

--- a/src/test/scala/com/kinja/amqp/persistence/MySqlMessageStoreSpec.scala
+++ b/src/test/scala/com/kinja/amqp/persistence/MySqlMessageStoreSpec.scala
@@ -424,7 +424,7 @@ class SessionRepositorySpec(implicit ee: ExecutionEnv) extends mutable.Specifica
 
 	trait S extends Scope with mutable.Around with H2Database {
 
-		val store = new MySqlMessageStore(processId, h2ds, h2ds)
+		val store = new MySqlMessageStore(processId, h2ds.getConnection, h2ds.getConnection)
 
 		import store._
 

--- a/src/test/scala/com/kinja/amqp/persistence/MySqlMessageStoreSpec.scala
+++ b/src/test/scala/com/kinja/amqp/persistence/MySqlMessageStoreSpec.scala
@@ -10,6 +10,7 @@ import org.scalacheck.{ Prop, Gen, Arbitrary }, Arbitrary.arbitrary
 
 import java.sql.Timestamp
 
+@SuppressWarnings(Array("org.brianmckenna.wartremover.warts.ExplicitImplicitTypes"))
 class SessionRepositorySpec(implicit ee: ExecutionEnv) extends mutable.Specification with ScalaCheck with ParseInitSql {
 
 	private val processId = "test-store"
@@ -118,28 +119,28 @@ class SessionRepositorySpec(implicit ee: ExecutionEnv) extends mutable.Specifica
 			store.saveMessage(msg)
 			val loaded = loadAllMessages
 			loaded === List(msg)
-			loaded.head.channelId must beNone
+			loaded.headOption.flatMap(_.channelId) must beNone
 		}
 		"save a message with undefined deliveryTag" in new S {
 			val msg = message.copy(deliveryTag = None)
 			store.saveMessage(msg)
 			val loaded = loadAllMessages
 			loaded === List(msg)
-			loaded.head.deliveryTag must beNone
+			loaded.headOption.flatMap(_.deliveryTag) must beNone
 		}
 		"save a message with undefined processedBy" in new S {
 			val msg = message.copy(processedBy = None)
 			store.saveMessage(msg)
 			val loaded = loadAllMessages
 			loaded === List(msg)
-			loaded.head.processedBy must beNone
+			loaded.headOption.flatMap(_.processedBy) must beNone
 		}
 		"save a message with undefined lockedAt" in new S {
 			val msg = message.copy(lockedAt = None)
 			store.saveMessage(msg)
 			val loaded = loadAllMessages
 			loaded === List(msg)
-			loaded.head.lockedAt must beNone
+			loaded.headOption.flatMap(_.lockedAt) must beNone
 		}
 		"save a message several times with autoinc id" in new S {
 			store.saveMessage(message)
@@ -302,23 +303,23 @@ class SessionRepositorySpec(implicit ee: ExecutionEnv) extends mutable.Specifica
 			loadAllMessages === toInsert
 
 			store.deleteMessage(2)
-			loadAllMessages === toInsert.filterNot(m => Set[Long](2).contains(m.id.get))
+			loadAllMessages === toInsert.filterNot(m => Set[Long](2).contains(m.id.getOrElse(0)))
 
 			store.deleteMessage(6)
-			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6).contains(m.id.get))
+			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6).contains(m.id.getOrElse(0)))
 
 			store.deleteMessage(3)
-			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3).contains(m.id.get))
+			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3).contains(m.id.getOrElse(0)))
 
 			store.deleteMessage(1)
-			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3, 1).contains(m.id.get))
+			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3, 1).contains(m.id.getOrElse(0)))
 
 			store.deleteMessage(7)
-			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3, 1, 7).contains(m.id.get))
+			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3, 1, 7).contains(m.id.getOrElse(0)))
 
 			// delete again
 			store.deleteMessage(6)
-			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3, 1, 7).contains(m.id.get))
+			loadAllMessages === toInsert.filterNot(m => Set[Long](2, 6, 3, 1, 7).contains(m.id.getOrElse(0)))
 		}
 		"not do anything with an empty table" in new S {
 			loadAllMessages === List()
@@ -459,10 +460,10 @@ class SessionRepositorySpec(implicit ee: ExecutionEnv) extends mutable.Specifica
 					try {
 						stmt.executeUpdate
 					} finally {
-						if (stmt != null) stmt.close
+						if (Option(stmt).isDefined) stmt.close
 					}
 				} finally {
-					if (conn != null) conn.close
+					if (Option(conn).isDefined) conn.close
 				}
 			}
 


### PR DESCRIPTION
### What does this PR do? How does it affect users?
- Removes the Play JSON dependency. Instead of Play's JSON serializers, you can now implement custom serializers and deserializers.
- Adds support for external connection pools: by replacing `javax.sql.DataSource` by a function that returns a `java.sql.Connection` we can use any connection pool that's capable of returning a connection.
- Fixes the shutdown process: not all schedules jobs were cancelled which resulted in attempts to connect to the database after the pool has been shut down.
- Sets up wartremover and fixes a few issues.
### How should this be tested (feature switches, URLs, special user permissions)?

`sbt test`
### Related Trello card, wiki page or blog posts

N/A
