### PR TITLE
Expect the message processor functions to return Future

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "2.0.0"
+version := "2.1.0"
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
@@ -1,17 +1,20 @@
 package com.kinja.amqp
 
+import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 trait AmqpConsumerInterface {
 
 	/**
 	 * Subscribes the message processor function to consume the queue described by params.
+	 * @param timeout The maximum amount of time to wait for processing to complete.
 	 * @param processor The pmessage processor function.
 	 */
-	def subscribe[A: Reads](processor: A => Unit): Unit
+	def subscribe[A: Reads](timeout: FiniteDuration)(processor: A => Future[Unit]): Unit
 
 	/**
 	 * Subscribes the message processor function to consume the queue described by params.
+	 * @param timeout The maximum amount of time to wait for processing to complete.
 	 * @param spacing The minimum amount of time that has to elapse between starting processing
 	 *        new messages. It can be used to define rate limiting, for example, setting 10
 	 *        seconds here means that only one message may be processed each 10 seconds, resulting
@@ -22,5 +25,5 @@ trait AmqpConsumerInterface {
 	 *        can immediately be started.
 	 * @param processor The pmessage processor function.
 	 */
-	def subscribe[A: Reads](spacing: FiniteDuration, processor: A => Unit): Unit
+	def subscribe[A: Reads](timeout: FiniteDuration, spacing: FiniteDuration, processor: A => Future[Unit]): Unit
 }

--- a/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
@@ -1,8 +1,9 @@
 package com.kinja.amqp
 
+import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 class NullAmqpConsumer extends AmqpConsumerInterface {
-	override def subscribe[A: Reads](processor: (A) => Unit): Unit = ()
-	override def subscribe[A: Reads](spacing: FiniteDuration, processor: (A) => Unit): Unit = ()
+	override def subscribe[A: Reads](timeout: FiniteDuration)(processor: (A) => Future[Unit]): Unit = ()
+	override def subscribe[A: Reads](timeout: FiniteDuration, spacing: FiniteDuration, processor: (A) => Future[Unit]): Unit = ()
 }


### PR DESCRIPTION
### What does this PR do? How does it affect users?

This change aims to prevent bugs when the processor function returns a `Future` of something. In that case we simply acknowledge the delivery to RabbitMQ before processing is complete and regardless of the errors that might arise. That's why all processor functions had to Await at the end which was very easy to miss. Now we explicitly require message processors to return `Future` and the delivery logic Awaits using the provided timeout.

Even though this change is backwards incompatible, nothing uses 2.0.0 yet so I'm only bumping this to 2.1.0 as a fix for 2.0.0.
### How should this be tested (feature switches, URLs, special user permissions)?

`sbt test`
### Related Trello card, wiki page or blog posts

N/A
