### PR TITLE
Adding store param to optionally turn off MySql storing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "2.1.0"
+version := "2.2.0"
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/AmqpProducerInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpProducerInterface.scala
@@ -3,5 +3,10 @@ package com.kinja.amqp
 import scala.concurrent.Future
 
 trait AmqpProducerInterface {
-	def publish[A: Writes](routingKey: String, message: A, saveTimeMillis: Long = System.currentTimeMillis()): Future[Unit]
+	def publish[A: Writes](
+		routingKey: String,
+		message: A,
+		saveTimeMillis: Long = System.currentTimeMillis()
+	): Future[Unit]
+
 }

--- a/src/main/scala/com/kinja/amqp/AtMostOnceAmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AtMostOnceAmqpProducer.scala
@@ -1,0 +1,34 @@
+package com.kinja.amqp
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor._
+import com.github.sstone.amqp.Amqp._
+import com.github.sstone.amqp.{ Amqp, ChannelOwner, ConnectionOwner }
+import com.rabbitmq.client.AMQP.BasicProperties
+import org.slf4j.{ Logger => Slf4jLogger }
+
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
+
+class AtMostOnceAmqpProducer(
+	exchangeName: String,
+	channelProvider: ProducerChannelProvider
+)(implicit val ec: ExecutionContext) extends AmqpProducerInterface {
+
+	private val channel: ActorRef = channelProvider.createChannel()
+
+	def publish[A: Writes](
+		routingKey: String,
+		message: A,
+		saveTimeMillis: Long = System.currentTimeMillis()
+	): Future[Unit] = {
+		val messageString = implicitly[Writes[A]].writes(message)
+		val bytes = messageString.getBytes(java.nio.charset.Charset.forName("UTF-8"))
+		val properties = new BasicProperties.Builder().deliveryMode(2).build()
+		channel ! Publish(
+			exchangeName, routingKey, bytes, properties = Some(properties), mandatory = true, immediate = false
+		)
+		Future.successful(())
+	}
+}

--- a/src/main/scala/com/kinja/amqp/ProducerChannelProvider.scala
+++ b/src/main/scala/com/kinja/amqp/ProducerChannelProvider.scala
@@ -1,0 +1,29 @@
+package com.kinja.amqp
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{ ActorRef, ActorSystem }
+import com.github.sstone.amqp.Amqp.{ DeclareExchange, ExchangeParameters, Record, Request }
+import com.github.sstone.amqp.{ Amqp, ChannelOwner, ConnectionOwner }
+
+import scala.concurrent.duration.FiniteDuration
+
+class ProducerChannelProvider(
+	connection: ActorRef,
+	actorSystem: ActorSystem,
+	connectionTimeOut: FiniteDuration,
+	exchange: ExchangeParameters
+) {
+
+	def createChannel(initialCommands: Seq[Request] = Seq.empty[Request]): ActorRef = {
+		val initList: Seq[Request] = Seq(Record(DeclareExchange(exchange))) ++ initialCommands
+
+		val channel: ActorRef = ConnectionOwner.createChildActor(
+			connection, ChannelOwner.props(init = initList)
+		)
+
+		Amqp.waitForConnection(actorSystem, connection, channel).await(connectionTimeOut.toSeconds, TimeUnit.SECONDS)
+
+		channel
+	}
+}


### PR DESCRIPTION
Creating a new producer type `AtMostOnceAmqpProducer`, which can be turned on with `guaranteedDelivery = false` config. This producer doesn't use `messageStore` to save messages.

cc: @stratiator 
