### PR TITLE
Fix for duplicated consumer reconnect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "3.1.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "3.1.2" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
@@ -60,12 +60,12 @@ class AmqpConsumer(
 			actorName)
 		supervisor ! Connect
 
-		val initDeadLetterExchangeRequest = params.deadLetterExchange.map(
-			exchangeParams => Record(DeclareExchange(exchangeParams))
+		val initDeadLetterExchangeRequest = params.deadLetterExchange.map[Request](
+			exchangeParams => DeclareExchange(exchangeParams)
 		)
 		// we don't have to declare bound exchange and the queue itself, because it's done with the AddBinding
-		val bindingRequest = Some(
-			Record(AddBinding(Binding(params.boundExchange, params.queueParams, params.bindingKey)))
+		val bindingRequest = Some[Request](
+			AddBinding(Binding(params.boundExchange, params.queueParams, params.bindingKey))
 		)
 		val initRequests = List(initDeadLetterExchangeRequest.toList, bindingRequest.toList).flatten
 

--- a/src/main/scala/com/kinja/amqp/AtLeastOnceAmqpProducer.scala
+++ b/src/main/scala/com/kinja/amqp/AtLeastOnceAmqpProducer.scala
@@ -27,9 +27,9 @@ class AtLeastOnceAmqpProducer(
 
 	private implicit val timeout: Timeout = Timeout(askTimeout)
 
-	private val initialCommands = Seq(
-		Record(ConfirmSelect),
-		Record(AddConfirmListener(createConfirmListener))
+	private val initialCommands = Seq[Request](
+		ConfirmSelect,
+		AddConfirmListener(createConfirmListener)
 	)
 	private val channel: ActorRef = channelProvider.createChannel(initialCommands)
 

--- a/src/main/scala/com/kinja/amqp/ProducerChannelProvider.scala
+++ b/src/main/scala/com/kinja/amqp/ProducerChannelProvider.scala
@@ -3,7 +3,7 @@ package com.kinja.amqp
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ ActorRef, ActorSystem }
-import com.github.sstone.amqp.Amqp.{ DeclareExchange, ExchangeParameters, Record, Request }
+import com.github.sstone.amqp.Amqp.{ DeclareExchange, ExchangeParameters, Request }
 import com.github.sstone.amqp.{ Amqp, ChannelOwner, ConnectionOwner }
 
 import scala.concurrent.duration.FiniteDuration
@@ -16,7 +16,7 @@ class ProducerChannelProvider(
 ) {
 
 	def createChannel(initialCommands: Seq[Request] = Seq.empty[Request]): ActorRef = {
-		val initList: Seq[Request] = Seq(Record(DeclareExchange(exchange))) ++ initialCommands
+		val initList: Seq[Request] = Seq(DeclareExchange(exchange)) ++ initialCommands
 
 		val channel: ActorRef = ConnectionOwner.createChildActor(
 			connection, ChannelOwner.props(init = initList)


### PR DESCRIPTION
The init request should not be Record type because it is causing
duplication in the request Log:
In case of consumer:
1. in disconnected state it is self forwarding all message from the request log
(requestLog initially contains the init messages)
2. change it's state to connected
3. in connected state each from incoming record message the content request will be put in the requestLog
   and the content request self forwarded too

Asana Task:
https://app.asana.com/0/492837961363500/798864824578600