### PR TITLE
Make prefetch count directly configurable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "4.0.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "5.0.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/AmqpClient.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClient.scala
@@ -90,7 +90,7 @@ class AmqpClient(
 					connection,
 					actorSystem,
 					configuration.connectionTimeOut,
-					configuration.defaultPrefetchSize,
+					configuration.defaultPrefetchCount,
 					logger
 				)(params)
 		}

--- a/src/main/scala/com/kinja/amqp/AmqpClient.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClient.scala
@@ -90,6 +90,7 @@ class AmqpClient(
 					connection,
 					actorSystem,
 					configuration.connectionTimeOut,
+					configuration.defaultPrefetchSize,
 					logger
 				)(params)
 		}

--- a/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
@@ -40,8 +40,8 @@ trait AmqpConfiguration {
 	val askTimeOut: FiniteDuration = config.getLong("messageQueue.askTimeoutInMilliSec").millis
 	val testMode: Boolean = Try(config.getBoolean("messageQueue.testMode")).getOrElse(false)
 
-	val defaultPrefetchSize: Option[Int] = Try {
-		config.getString("messageQueue.defaults.prefetchSize") match {
+	val defaultPrefetchCount: Option[Int] = Try {
+		config.getString("messageQueue.defaults.prefetchCount") match {
 			case v if "none".equalsIgnoreCase(v) => None
 			case v => Try { v.toInt }.toOption
 		}

--- a/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConfiguration.scala
@@ -3,11 +3,11 @@ package com.kinja.amqp
 import com.rabbitmq.client.Address
 import com.github.sstone.amqp.Amqp._
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigException.{ BadValue, Missing }
+import com.typesafe.config.ConfigException.Missing
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.util.{ Success, Try }
+import scala.util.Try
 import scala.util.control.NonFatal
 
 final case class ResendLoopConfig(

--- a/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
@@ -19,7 +19,7 @@ class AmqpConsumer(
 	connection: ActorRef,
 	actorSystem: ActorSystem,
 	connectionTimeOut: FiniteDuration,
-	defaultPrefetchSize: Option[Int],
+	defaultPrefetchCount: Option[Int],
 	logger: Slf4jLogger
 )(val params: QueueWithRelatedParameters) extends AmqpConsumerInterface {
 
@@ -43,7 +43,7 @@ class AmqpConsumer(
 	 * @inheritdoc
 	 */
 	override def subscribe[A: Reads](timeout: FiniteDuration)(processor: A => Future[Unit]): Unit = {
-		subscribe(timeout, defaultPrefetchSize, Duration.Zero, processor)
+		subscribe(timeout, defaultPrefetchCount, Duration.Zero, processor)
 	}
 
 	/**
@@ -65,7 +65,7 @@ class AmqpConsumer(
 		spacing: FiniteDuration,
 		processor: A => Future[Unit]): Unit = {
 
-		subscribe(timeout, defaultPrefetchSize, spacing, processor)
+		subscribe(timeout, defaultPrefetchCount, spacing, processor)
 	}
 
 	/**

--- a/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumerInterface.scala
@@ -27,6 +27,19 @@ trait AmqpConsumerInterface {
 	/**
 	 * Subscribes the message processor function to consume the queue described by params.
 	 * @param timeout The maximum amount of time to wait for processing to complete.
+	 * @param prefetchCount The maximum amount of "in flight" messages.
+	 *        If not set to None the prefetch count will be unlimited.
+	 *        Default value set to 10.
+	 *        (https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.qos.prefetch-count)
+	 * @param processor The message processor function.
+	 */
+	def subscribe[A: Reads](
+		timeout: FiniteDuration,
+		prefetchCount: Option[Int])(processor: A => Future[Unit]): Unit
+
+	/**
+	 * Subscribes the message processor function to consume the queue described by params.
+	 * @param timeout The maximum amount of time to wait for processing to complete.
 	 * @param spacing The minimum amount of time that has to elapse between starting processing
 	 *        new messages. It can be used to define rate limiting, for example, setting 10
 	 *        seconds here means that only one message may be processed each 10 seconds, resulting
@@ -38,4 +51,28 @@ trait AmqpConsumerInterface {
 	 * @param processor The pmessage processor function.
 	 */
 	def subscribe[A: Reads](timeout: FiniteDuration, spacing: FiniteDuration, processor: A => Future[Unit]): Unit
+
+	/**
+	 * Subscribes the message processor function to consume the queue described by params.
+	 * @param timeout The maximum amount of time to wait for processing to complete.
+	 * @param prefetchCount The maximum amount of "in flight" messages.
+	 *        If not set the prefetch count will be unlimited.
+	 *        If spacing set greater than zero this value overridden with 1.
+	 *        Default value is 10.
+	 *        (https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.qos.prefetch-count)
+	 * @param spacing The minimum amount of time that has to elapse between starting processing
+	 *        new messages. It can be used to define rate limiting, for example, setting 10
+	 *        seconds here means that only one message may be processed each 10 seconds, resulting
+	 *        in a processing rate of 0.1 message/sec. Note that this is not the time to wait
+	 *        between processing messages (end of last and beginning of next) but rather
+	 *        the time between the start of each processing. This means, sticking to the previous
+	 *        example, that if processing took more than 10 seconds, processing the next message
+	 *        can immediately be started.
+	 * @param processor The pmessage processor function.
+	 */
+	def subscribe[A: Reads](
+		timeout: FiniteDuration,
+		prefetchCount: Option[Int],
+		spacing: FiniteDuration,
+		processor: A => Future[Unit]): Unit
 }

--- a/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpConsumer.scala
@@ -7,5 +7,7 @@ class NullAmqpConsumer extends AmqpConsumerInterface {
 	override def disconnect(): Unit = ()
 	override def reconnect(): Unit = ()
 	override def subscribe[A: Reads](timeout: FiniteDuration)(processor: (A) => Future[Unit]): Unit = ()
+	override def subscribe[A: Reads](timeout: FiniteDuration, prefetchCount: Option[Int])(processor: (A) => Future[Unit]): Unit = ()
 	override def subscribe[A: Reads](timeout: FiniteDuration, spacing: FiniteDuration, processor: (A) => Future[Unit]): Unit = ()
+	override def subscribe[A: Reads](timeout: FiniteDuration, prefetchCount: Option[Int], spacing: FiniteDuration, processor: (A) => Future[Unit]): Unit = ()
 }


### PR DESCRIPTION
## What this PR do?
Make prefetch count directly configurable and change the default value to 10 from 0 which means unlimited to avoid prefetching big amount of message and keep them in memory in the client side.
Bump version to 5.0.0
## Asana Task:
https://app.asana.com/0/0/613906267412251/f