### PR TITLE
Fix Connection timeout handling + update amqp-client to 2.0.2 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "5.0.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "5.0.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 
@@ -36,7 +36,7 @@ updateOptions := updateOptions.value.withCachedResolution(true)
 val akkaVersion = "2.5.11"
 
 libraryDependencies ++= Seq(
-    "com.kinja" %% "amqp-client" % "2.0.1",
+    "com.kinja" %% "amqp-client" % "2.0.2",
     "com.kinja" %% "warts" % "1.0.2",
     "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
     "ch.qos.logback" % "logback-classic" % "1.0.0" % Provided,

--- a/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
@@ -45,11 +45,12 @@ class AmqpClientFactory {
 		factory.setUsername(config.username)
 		factory.setPassword(config.password)
 		factory.setRequestedHeartbeat(config.heartbeatRate)
+		factory.setConnectionTimeout(config.connectionTimeOut.toMillis.toInt)
 
 		actorSystem.actorOf(
 			ConnectionOwner.props(
-				factory,
-				config.connectionTimeOut,
+				connFactory = factory,
+				reconnectionDelay = config.connectionTimeOut,
 				addresses = Some(config.addresses)
 			)
 		)

--- a/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
@@ -224,7 +224,7 @@ class Listener[A: Reads](
 			originalSender ! ack
 			context.become(idle)
 		case Delivery(_, envelope, _, _) =>
-			originalSender ! Reject(envelope.getDeliveryTag, requeue = true)
+			sender ! Reject(envelope.getDeliveryTag, requeue = true)
 	}
 
 }

--- a/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumer.scala
@@ -224,7 +224,7 @@ class Listener[A: Reads](
 			originalSender ! ack
 			context.become(idle)
 		case Delivery(_, envelope, _, _) =>
-			sender ! Reject(envelope.getDeliveryTag, requeue = true)
+			originalSender ! Reject(envelope.getDeliveryTag, requeue = true)
 	}
 
 }


### PR DESCRIPTION
- Fixing connection timeout handling: It was not set before in the connection factory.
- Update to amqp-client 2.0.2


### Asana Task:
https://app.asana.com/0/0/869432835856947/f