### PR TITLE
Bump amqp-client-akka23 version to 2.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider-akka23"
 
-version := "5.0.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "5.1.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 
@@ -36,7 +36,7 @@ updateOptions := updateOptions.value.withCachedResolution(true)
 val akkaVersion = "2.3.13"
 
 libraryDependencies ++= Seq(
-    "com.kinja" %% "amqp-client-akka23" % "2.0.2",
+    "com.kinja" %% "amqp-client-akka23" % "2.1.0",
     "com.kinja" %% "warts" % "1.0.2",
     "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
     "ch.qos.logback" % "logback-classic" % "1.0.0" % Provided,


### PR DESCRIPTION
Bump amqp-client-akka23 version to 2.1.0 to support channel connection status listening.

Backport of PR #40 to akka 2.3.x product line.

### Asana Task
https://app.asana.com/0/0/1108393216209647/f