### PR TITLE
Define separate AmqpConsumerClientInterface for consumer only use cases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "5.2.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "6.0.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider"
 
-version := "5.1.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "5.2.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/AmqpClient.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClient.scala
@@ -45,15 +45,15 @@ class AmqpClient(
 
 		}
 
-	def getMessageProducer(exchangeName: String): AmqpProducerInterface = {
+	override def getMessageProducer(exchangeName: String): AmqpProducerInterface = {
 		producers.getOrElse(exchangeName, throw new MissingProducerException(exchangeName))
 	}
 
-	def getMessageConsumer(queueName: String): AmqpConsumer = {
+	override def getMessageConsumer(queueName: String): AmqpConsumer = {
 		consumers.getOrElse(queueName, throw new MissingConsumerException(queueName))
 	}
 
-	def startMessageRepeater() = {
+	def startMessageRepeater(): Unit = {
 		repeater.foreach(_.startSchedule(ec))
 	}
 
@@ -96,7 +96,7 @@ class AmqpClient(
 		}
 	}
 
-	override def addConnectionListener(listener: ActorRef): Unit = connection ! AddStatusListener(listener)
+	def addConnectionListener(listener: ActorRef): Unit = connection ! AddStatusListener(listener)
 
 	override def shutdown(): Future[Unit] = {
 		implicit val ex: ExecutionContext = actorSystem.dispatcher

--- a/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
@@ -1,13 +1,15 @@
 package com.kinja.amqp
 
 import com.kinja.amqp.persistence.{ InMemoryMessageBufferDecorator, MessageStore }
-
-import akka.actor.{ ActorSystem, ActorRef }
+import akka.actor.{ ActorRef, ActorSystem }
 import com.github.sstone.amqp.ConnectionOwner
 import com.rabbitmq.client.ConnectionFactory
-import java.sql.Connection
+import utils.Utils._
+
 import org.slf4j.Logger
-import scala.concurrent.ExecutionContext
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.control.NonFatal
 
 class AmqpClientFactory {
 
@@ -15,21 +17,24 @@ class AmqpClientFactory {
 		config: AmqpConfiguration,
 		actorSystem: ActorSystem,
 		logger: Logger,
-		ec: ExecutionContext
+		ec: ExecutionContext,
+		connectionListener: Option[ActorRef]
 	): AmqpConsumerClientInterface =
-		createClient(config, actorSystem, logger, ec, Map.empty[AtLeastOnceGroup, MessageStore])
+		createClient(config, actorSystem, logger, ec, Map.empty[AtLeastOnceGroup, MessageStore], connectionListener)
 
 	def createClient(
 		config: AmqpConfiguration,
 		actorSystem: ActorSystem,
 		logger: Logger,
 		ec: ExecutionContext,
-		messageStores: Map[AtLeastOnceGroup, MessageStore]
+		messageStores: Map[AtLeastOnceGroup, MessageStore],
+		connectionListener: Option[ActorRef]
 	): AmqpClientInterface =
 		{
 			if (config.testMode) {
 				new NullAmqpClient
 			} else {
+				implicit val ex: ExecutionContext = ec
 				val connection: ActorRef = createConnection(config, actorSystem)
 				val bufferedMessageStores =
 					messageStores.map {
@@ -38,7 +43,7 @@ class AmqpClientFactory {
 								createMessageStore(config, actorSystem, logger, ec, messageStore)
 					}
 
-				new AmqpClient(
+				val client = new AmqpClient(
 					connection,
 					actorSystem,
 					config,
@@ -46,6 +51,14 @@ class AmqpClientFactory {
 					bufferedMessageStores,
 					ec
 				)
+				connectionListener.foreach(client.addConnectionListener(_))
+				ignore(Future {
+					client.startMessageRepeater()
+				}.recover {
+					case NonFatal(e) =>
+						logger.error("RabbitMQ message buffer processor failed to start: " + e.getMessage)
+				})
+				client
 			}
 		}
 

--- a/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
@@ -10,6 +10,15 @@ import org.slf4j.Logger
 import scala.concurrent.ExecutionContext
 
 class AmqpClientFactory {
+
+	def createConsumerClient(
+		config: AmqpConfiguration,
+		actorSystem: ActorSystem,
+		logger: Logger,
+		ec: ExecutionContext
+	): AmqpConsumerClientInterface =
+		createClient(config, actorSystem, logger, ec, Map.empty[AtLeastOnceGroup, MessageStore])
+
 	def createClient(
 		config: AmqpConfiguration,
 		actorSystem: ActorSystem,

--- a/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientFactory.scala
@@ -4,7 +4,7 @@ import com.kinja.amqp.persistence.{ InMemoryMessageBufferDecorator, MessageStore
 import akka.actor.{ ActorRef, ActorSystem }
 import com.github.sstone.amqp.ConnectionOwner
 import com.rabbitmq.client.ConnectionFactory
-import utils.Utils._
+import utils._
 
 import org.slf4j.Logger
 
@@ -13,6 +13,9 @@ import scala.util.control.NonFatal
 
 class AmqpClientFactory {
 
+	/**
+	 * Create an AMQP Client which only provides API for consumer creation.
+	 */
 	def createConsumerClient(
 		config: AmqpConfiguration,
 		actorSystem: ActorSystem,
@@ -22,7 +25,33 @@ class AmqpClientFactory {
 	): AmqpConsumerClientInterface =
 		createClient(config, actorSystem, logger, ec, Map.empty[AtLeastOnceGroup, MessageStore], connectionListener)
 
+	/**
+	 * Create an AMQP Client which provides API for consumer and producer creation.
+	 */
 	def createClient(
+		config: AmqpConfiguration,
+		actorSystem: ActorSystem,
+		logger: Logger,
+		ec: ExecutionContext,
+		messageStore: (AtLeastOnceGroup, MessageStore),
+		connectionListener: Option[ActorRef]
+	): AmqpClientInterface =
+		createClient(config, actorSystem, logger, ec, Map(messageStore), connectionListener)
+
+	/**
+	 * Create an AMQP Client which provides API for consumer and producer creation.
+	 */
+	def createClient(
+		config: AmqpConfiguration,
+		actorSystem: ActorSystem,
+		logger: Logger,
+		ec: ExecutionContext,
+		messageStores: ::[(AtLeastOnceGroup, MessageStore)],
+		connectionListener: Option[ActorRef]
+	): AmqpClientInterface =
+		createClient(config, actorSystem, logger, ec, messageStores.toMap, connectionListener)
+
+	private def createClient(
 		config: AmqpConfiguration,
 		actorSystem: ActorSystem,
 		logger: Logger,

--- a/src/main/scala/com/kinja/amqp/AmqpClientInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientInterface.scala
@@ -4,6 +4,4 @@ trait AmqpClientInterface extends AmqpConsumerClientInterface {
 
 	def getMessageProducer(exchangeName: String): AmqpProducerInterface
 
-	def startMessageRepeater(): Unit
-
 }

--- a/src/main/scala/com/kinja/amqp/AmqpClientInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientInterface.scala
@@ -1,21 +1,9 @@
 package com.kinja.amqp
 
-import akka.actor.ActorRef
+trait AmqpClientInterface extends AmqpConsumerClientInterface {
 
-import scala.concurrent.Future
-
-trait AmqpClientInterface {
 	def getMessageProducer(exchangeName: String): AmqpProducerInterface
-
-	def getMessageConsumer(queueName: String): AmqpConsumerInterface
-
-	def addConnectionListener(listener: ActorRef): Unit
 
 	def startMessageRepeater(): Unit
 
-	def shutdown(): Future[Unit]
-
-	def disconnect(): Unit
-
-	def reconnect(): Unit
 }

--- a/src/main/scala/com/kinja/amqp/AmqpConsumerClientInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumerClientInterface.scala
@@ -1,0 +1,18 @@
+package com.kinja.amqp
+
+import akka.actor.ActorRef
+
+import scala.concurrent.Future
+
+trait AmqpConsumerClientInterface {
+
+	def getMessageConsumer(queueName: String): AmqpConsumerInterface
+
+	def addConnectionListener(listener: ActorRef): Unit
+
+	def shutdown(): Future[Unit]
+
+	def disconnect(): Unit
+
+	def reconnect(): Unit
+}

--- a/src/main/scala/com/kinja/amqp/AmqpConsumerClientInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumerClientInterface.scala
@@ -1,14 +1,10 @@
 package com.kinja.amqp
 
-import akka.actor.ActorRef
-
 import scala.concurrent.Future
 
 trait AmqpConsumerClientInterface {
 
 	def getMessageConsumer(queueName: String): AmqpConsumerInterface
-
-	def addConnectionListener(listener: ActorRef): Unit
 
 	def shutdown(): Future[Unit]
 

--- a/src/main/scala/com/kinja/amqp/NullAmqpClient.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpClient.scala
@@ -9,9 +9,9 @@ class NullAmqpClient extends AmqpClientInterface {
 
 	override def getMessageConsumer(queueName: String): AmqpConsumerInterface = new NullAmqpConsumer
 
-	override def startMessageRepeater(): Unit = {}
+	def startMessageRepeater(): Unit = {}
 
-	override def addConnectionListener(listener: ActorRef): Unit = {}
+	def addConnectionListener(listener: ActorRef): Unit = {}
 
 	override def shutdown(): Future[Unit] = Future.successful(())
 


### PR DESCRIPTION
The change address two problem:

- We have a lot of services which are using messagestores while they only have consumers.
 The problem with this, we make almost 6 Million request per day which are totally useless: https://bit.ly/2T5LhY0
- Make it harder to forget define messagestore for the client if we are start using publishers in a service

Example usage: 
Consumer only: https://github.com/gawkermedia/kinja-autotagging/pull/66
Consumer + Producer: https://github.com/gawkermedia/kinja-core/pull/4011