### PR TITLE
Define separate AmqpConsumerClientInterface for consumer only use cases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.scalastyle.sbt.ScalastylePlugin
 
 name := "amqp-client-provider-akka23"
 
-version := "5.1.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "6.0.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/AmqpClient.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClient.scala
@@ -45,15 +45,15 @@ class AmqpClient(
 
 		}
 
-	def getMessageProducer(exchangeName: String): AmqpProducerInterface = {
+	override def getMessageProducer(exchangeName: String): AmqpProducerInterface = {
 		producers.getOrElse(exchangeName, throw new MissingProducerException(exchangeName))
 	}
 
-	def getMessageConsumer(queueName: String): AmqpConsumer = {
+	override def getMessageConsumer(queueName: String): AmqpConsumer = {
 		consumers.getOrElse(queueName, throw new MissingConsumerException(queueName))
 	}
 
-	def startMessageRepeater() = {
+	def startMessageRepeater(): Unit = {
 		repeater.foreach(_.startSchedule(ec))
 	}
 
@@ -96,7 +96,7 @@ class AmqpClient(
 		}
 	}
 
-	override def addConnectionListener(listener: ActorRef): Unit = connection ! AddStatusListener(listener)
+	def addConnectionListener(listener: ActorRef): Unit = connection ! AddStatusListener(listener)
 
 	override def shutdown(): Future[Unit] = {
 		implicit val ex: ExecutionContext = actorSystem.dispatcher

--- a/src/main/scala/com/kinja/amqp/AmqpClientInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpClientInterface.scala
@@ -1,21 +1,7 @@
 package com.kinja.amqp
 
-import akka.actor.ActorRef
+trait AmqpClientInterface extends AmqpConsumerClientInterface {
 
-import scala.concurrent.Future
-
-trait AmqpClientInterface {
 	def getMessageProducer(exchangeName: String): AmqpProducerInterface
 
-	def getMessageConsumer(queueName: String): AmqpConsumerInterface
-
-	def addConnectionListener(listener: ActorRef): Unit
-
-	def startMessageRepeater(): Unit
-
-	def shutdown(): Future[Unit]
-
-	def disconnect(): Unit
-
-	def reconnect(): Unit
 }

--- a/src/main/scala/com/kinja/amqp/AmqpConsumerClientInterface.scala
+++ b/src/main/scala/com/kinja/amqp/AmqpConsumerClientInterface.scala
@@ -1,0 +1,14 @@
+package com.kinja.amqp
+
+import scala.concurrent.Future
+
+trait AmqpConsumerClientInterface {
+
+	def getMessageConsumer(queueName: String): AmqpConsumerInterface
+
+	def shutdown(): Future[Unit]
+
+	def disconnect(): Unit
+
+	def reconnect(): Unit
+}

--- a/src/main/scala/com/kinja/amqp/NullAmqpClient.scala
+++ b/src/main/scala/com/kinja/amqp/NullAmqpClient.scala
@@ -9,9 +9,9 @@ class NullAmqpClient extends AmqpClientInterface {
 
 	override def getMessageConsumer(queueName: String): AmqpConsumerInterface = new NullAmqpConsumer
 
-	override def startMessageRepeater(): Unit = {}
+	def startMessageRepeater(): Unit = {}
 
-	override def addConnectionListener(listener: ActorRef): Unit = {}
+	def addConnectionListener(listener: ActorRef): Unit = {}
 
 	override def shutdown(): Future[Unit] = Future.successful(())
 


### PR DESCRIPTION
Backport of the #42 PR.

* Define separate interface AmqpConsumerClientInterface

The change address two problem:

- We have a lot of services which are using messagestores while they only have consumers.
 The problem with this, we make almost 6 Million request per day which are totally useless: https://bit.ly/2T5LhY0
- Make it harder to forget define messagestore for the client if we are start using publishers in a service

* Make the client creation less errorprone:

- no need for the separate repeater start (become part of the creation)
- no need for the separate add connection status listener (become part of the creation)
- remove unused import
- make method overridings explicit

* Change version to 6.0.0 as API breaking changes was made

* Make producer creation without messagestore harder