### PR TITLE
Optimize message buffer processing

### DIFF
--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
@@ -36,6 +36,10 @@ class InMemoryMessageBufferDecorator(
 
 	logger.debug("Memory flusher scheduled")
 
+	override def hasMessageToProcess(): Future[Boolean] = {
+		messageStore.hasMessageToProcess()
+	}
+
 	override def saveConfirmations(confirms: List[MessageConfirmation]): Future[Unit] = {
 		val (multiples, singles) = confirms.partition(_.multiple)
 		// we don't save every multiple confirmation here,

--- a/src/main/scala/com/kinja/amqp/persistence/MessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/MessageStore.scala
@@ -8,6 +8,11 @@ import scala.concurrent.Future
 trait MessageStore {
 
 	/**
+	 * Check if the storage has message to be process.
+	 */
+	def hasMessageToProcess(): Future[Boolean]
+
+	/**
 	 * Save a list of confirmations to the storage
 	 *
 	 * @param confirms Confirmations to save

--- a/src/main/scala/com/kinja/amqp/persistence/NullMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/NullMessageStore.scala
@@ -6,6 +6,8 @@ import scala.concurrent.Future
 
 object NullMessageStore extends MessageStore {
 
+	override def hasMessageToProcess(): Future[Boolean] = Future.successful(false)
+
 	override def saveMessages(msg: List[Message]): Future[Unit] = Future.successful(())
 
 	override def saveConfirmations(confirms: List[MessageConfirmation]): Future[Unit] = Future.successful(())


### PR DESCRIPTION
Optimize the behavior off MessageBufferProcessor:

- skip steps in MessageBufferProcessor.processingMessageBuffer steps if the rabbit_messages table is empty (only make the full process once in every 100 iteration)
-  don't allow to start the next processing of message buffer before when there is a running one.

### Asana Task
https://app.asana.com/0/0/1112454564210200/f