### PR TITLE
Only save confirmations to db if we messages there

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scalariform.formatter.preferences._
 
 name := "amqp-client-provider"
 
-version := "9.0.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "9.0.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 


### PR DESCRIPTION
### What does this PR do? How does it affect users?

- Only save confirmations to db if we have messages there
- bump version to 9.0.1

### How should this be tested (feature switches, URLs, special user permissions)?
with test application, simulating connection problems

### Related Asana task, wiki page or blog posts
https://app.asana.com/0/0/1113808737989320/f