### PR TITLE
Introduce AwsAZMessageStore interface

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scalariform.formatter.preferences._
 
 name := "amqp-client-provider"
 
-version := "10.0.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "10.1.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/persistence/AwsAZMessageStore.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/AwsAZMessageStore.scala
@@ -1,0 +1,7 @@
+package com.kinja.amqp.persistence
+
+/**
+  * Interface for marking message stores which persist data only in one AWS availability zone.
+  * (Data available only for one cluster in our case.)
+  */
+trait AwsAZMessageStore extends MessageStore


### PR DESCRIPTION
### What does this PR do? How does it affect users?
Introduce Marker interface for message stores which only store data in one aws availability zone.

Motivation:
 Be able to distinct between mysql messagestore and redis messagestore in queue-based-migration without the need of depend on them.
### How should this be tested (feature switches, URLs, special user permissions)?
---
### Related Asana task, wiki page or blog posts
https://app.asana.com/0/0/1138172984697826/f