### PR TITLE
Set flushing memory log level to debug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scalariform.formatter.preferences._
 
 name := "amqp-client-provider"
 
-version := "11.0.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "11.0.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
@@ -80,7 +80,7 @@ class InMemoryMessageBufferDecorator(
 	}
 
 	private def flushMemoryBufferToMessageStore(): Future[Unit] = {
-		logger.info("Flushing memory buffer to message store...")
+		logger.debug("Flushing memory buffer to message store...")
 
 		if (logger.isInfoEnabled) {
 			ignore(inMemoryMessageBuffer ? LogBufferStatistics(logger))


### PR DESCRIPTION
### What does this PR do? How does it affect users?
Set the log level of "Flushing memory buffer to message store..." to debug, because it's a bit excessive in the logs. Check kinja-core's logs where the (not yet) used image removal code lives.
![Screenshot 2019-12-16 at 12 26 07](https://user-images.githubusercontent.com/33150179/70903658-9c711680-1fff-11ea-83c4-afba3b6a51ae.png)


### How should this be tested (feature switches, URLs, special user permissions)?
N/A

### Related Asana task, wiki page or blog posts
https://app.asana.com/0/1116090821598246/1152441880882329