### PR TITLE
Akka 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ val specs2Version = "4.8.1"
 
 libraryDependencies ++= Seq(
     "com.kinja" %% "amqp-client" % "2.3.0",
-    "com.kinja" %% "warts" % "1.0.5" % Provided,
+    "com.kinja" %% "warts" % "1.0.6" % Provided,
     "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
     "ch.qos.logback" % "logback-classic" % "1.0.0" % Provided,
     // Test dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ scalacOptions ++= Seq(
 	"-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
 	"-Xlint",                            // Ensure best practices are being followed.
 	"-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+	"-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
 	"-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
 	"-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
 	"-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
@@ -33,29 +34,14 @@ scalacOptions ++= Seq(
 	"-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
 	"-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
 	"-Ywarn-dead-code",                  // Fail when dead code is present. Prevents accidentally unreachable code.
-	"-Ywarn-dead-code",                  // Fail when dead code is present. Prevents accidentally unreachable code.
 	"-Ywarn-numeric-widen",              // Warn when numerics are widened.
-	"-Ywarn-value-discard"               // Prevent accidental discarding of results in unit functions.
-)
-
-// Enable compiler checks added in Scala 2.12
-scalacOptions ++= (CrossVersion.partialVersion((scalaVersion in ThisProject).value) match {
-	case Some((2, scalaMajor)) if scalaMajor >= 12 =>
-		Seq(
-			"-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-			"-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-			"-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-			"-Ywarn-unused:locals",              // Warn if a local definition is unused.
-//			"-Ywarn-unused:params",              // Warn if a value parameter is unused. Disabled due to false positives.
-			"-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-			"-Ywarn-unused:privates"             // Warn if a private member is unused.
-		)
-	case _ =>
-		Seq()
-})
-
-javacOptions ++= Seq(
-    "-Xlint:deprecation"
+	"-Ywarn-value-discard",              // Prevent accidental discarding of results in unit functions.
+	"-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+	"-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+	"-Ywarn-unused:locals",              // Warn if a local definition is unused.
+	// "-Ywarn-unused:params",              // Warn if a value parameter is unused. Disabled due to false positives.
+	"-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+	"-Ywarn-unused:privates"             // Warn if a private member is unused.
 )
 
 updateOptions := updateOptions.value.withCachedResolution(true)
@@ -75,13 +61,6 @@ libraryDependencies ++= Seq(
     "org.specs2" %% "specs2-scalacheck" % specs2Version % Test,
     "com.h2database" % "h2" % "1.4.187" % Test
 )
-
-libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-	case Some((2, scalaMajor)) if scalaMajor < 13 =>
-	  Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1")
-	case _ =>
-	  Seq()
-})
 
 // Code formatting
 scalariformAutoformat := FORMAT_CODE

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scalariform.formatter.preferences._
 
 name := "amqp-client-provider"
 
-version := "11.0.2" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "11.1.0" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 
@@ -64,7 +64,7 @@ val akkaVersion = "2.6.3"
 val specs2Version = "4.8.1"
 
 libraryDependencies ++= Seq(
-    "com.kinja" %% "amqp-client" % "2.2.3",
+    "com.kinja" %% "amqp-client" % "2.3.0",
     "com.kinja" %% "warts" % "1.0.5" % Provided,
     "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
     "ch.qos.logback" % "logback-classic" % "1.0.0" % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ import scalariform.formatter.preferences._
 
 name := "amqp-client-provider"
 
-version := "11.0.1" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
+version := "11.0.2" + (if (RELEASE_BUILD) "" else "-SNAPSHOT")
 
 organization := "com.kinja"
 
-crossScalaVersions := Seq("2.12.8", "2.13.0", "2.11.12")
+crossScalaVersions := Seq("2.13.1")
 
 scalaVersion := crossScalaVersions.value.head
 
@@ -60,11 +60,11 @@ javacOptions ++= Seq(
 
 updateOptions := updateOptions.value.withCachedResolution(true)
 
-val akkaVersion = "2.5.23"
-val specs2Version = "4.5.1"
+val akkaVersion = "2.6.3"
+val specs2Version = "4.8.1"
 
 libraryDependencies ++= Seq(
-    "com.kinja" %% "amqp-client" % "2.2.2",
+    "com.kinja" %% "amqp-client" % "2.2.3",
     "com.kinja" %% "warts" % "1.0.5" % Provided,
     "com.typesafe.akka" %% "akka-actor" % akkaVersion % Provided,
     "ch.qos.logback" % "logback-classic" % "1.0.0" % Provided,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers := Seq(
-	"Kinja Public Group" at sys.env.getOrElse("KINJA_PUBLIC_REPO", "https://kinjajfrog.jfrog.io/kinjajfrog/sbt-virtual"),
+	"Kinja Public" at sys.env.getOrElse("KINJA_PUBLIC_REPO", "https://kinjajfrog.jfrog.io/kinjajfrog/sbt-virtual"),
 	"sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 )
 
@@ -12,7 +12,7 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 // Kinja build plugin
-addSbtPlugin("com.kinja.sbtplugins" %% "kinja-build-plugin" % "3.2.4")
+addSbtPlugin("com.kinja.sbtplugins" %% "kinja-build-plugin" % "3.2.5")
 
 // Scala linting plugin
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.2")

--- a/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
+++ b/src/main/scala/com/kinja/amqp/MessageBufferProcessor.scala
@@ -41,7 +41,7 @@ class MessageBufferProcessor(
 	private val resendSchedule = actorSystem.actorOf(Props(new Actor with Stash {
 
 		def createSchedule(implicit ec: ExecutionContext): Cancellable =
-			actorSystem.scheduler.schedule(initialDelay, bufferProcessInterval, self, RunScheduled)
+			actorSystem.scheduler.scheduleAtFixedRate(initialDelay, bufferProcessInterval, self, RunScheduled)
 
 		def receive: Receive = idle
 

--- a/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
+++ b/src/main/scala/com/kinja/amqp/persistence/InMemoryMessageBufferDecorator.scala
@@ -31,9 +31,9 @@ class InMemoryMessageBufferDecorator(
 
 	logger.debug("Scheduling memory flusher...")
 
-	private val memoryFlushSchedule: Cancellable = actorSystem.scheduler.schedule(
+	private val memoryFlushSchedule: Cancellable = actorSystem.scheduler.scheduleAtFixedRate(
 		1.second, memoryFlushInterval
-	)(ignore(flushMemoryBufferToMessageStore()))
+	)(new Runnable { override def run(): Unit = ignore(flushMemoryBufferToMessageStore()) })
 
 	logger.debug("Memory flusher scheduled")
 


### PR DESCRIPTION
Bumping Akka version to 2.6 because that's what used by the latest Play framework.
This means dropping support for Scala 2.11. And removing Scala 2.12 because we no longer use it.